### PR TITLE
chore: fix for issues with `getListItem` and `getListItems` handling variables

### DIFF
--- a/action.go
+++ b/action.go
@@ -319,15 +319,15 @@ func typeCheck(param *parameterDefinition, argument *actionArgument) {
 			validActionOutput(param.name, param.validType, argVal)
 			return
 		}
-		if argValueType != param.validType && param.validType != Variable {
-			parserError(fmt.Sprintf("Invalid variable value %v (%s) for argument '%s' (%s).\n%s",
-				argVal,
-				argValueType,
-				param.name,
-				param.validType,
-				generateActionDefinition(*param, false, false),
-			))
-		}
+		// if argValueType != param.validType && param.validType != Variable {
+		// 	parserError(fmt.Sprintf("Invalid variable value %v (%s) for argument '%s' (%s).\n%s",
+		// 		argVal,
+		// 		argValueType,
+		// 		param.name,
+		// 		param.validType,
+		// 		generateActionDefinition(*param, false, false),
+		// 	))
+		// }
 	case argValueType == Question:
 	case argValueType == Nil:
 	case argument.valueType != param.validType:

--- a/actions_std.go
+++ b/actions_std.go
@@ -3897,9 +3897,11 @@ func scriptingActions() {
 			},
 		},
 		check: func(args []actionArgument) {
-			args[1] = actionArgument{
-				valueType: Integer,
-				value:     incrementValue(args[1].value),
+			if args[1].valueType != Variable {
+				args[1] = actionArgument{
+					valueType: Integer,
+					value:     incrementValue(args[1].value),
+				}
 			}
 		},
 		addParams: func(args []actionArgument) []plistData {
@@ -3932,13 +3934,17 @@ func scriptingActions() {
 			},
 		},
 		check: func(args []actionArgument) {
-			args[1] = actionArgument{
-				valueType: Integer,
-				value:     incrementValue(args[1].value),
+			if args[1].valueType != Variable {
+				args[1] = actionArgument{
+					valueType: Integer,
+					value:     incrementValue(args[1].value),
+				}
 			}
-			args[2] = actionArgument{
-				valueType: Integer,
-				value:     incrementValue(args[2].value),
+			if args[2].valueType != Variable {
+				args[2] = actionArgument{
+					valueType: Integer,
+					value:     incrementValue(args[2].value),
+				}
 			}
 		},
 		addParams: func(args []actionArgument) []plistData {


### PR DESCRIPTION
Potential fix for issues https://github.com/electrikmilk/cherri/issues/41 and https://github.com/electrikmilk/cherri/issues/42.

I commented out the code that causes the type-related error (https://github.com/electrikmilk/cherri/issues/42), so we can plan for a check that allows variables through reasonably.