### PR TITLE
Implement raw strings

### DIFF
--- a/action.go
+++ b/action.go
@@ -329,6 +329,7 @@ func typeCheck(param *parameterDefinition, argument *actionArgument) {
 		}
 	case argValueType == Question:
 	case argValueType == Nil:
+	case param.validType == String && argument.valueType == RawString:
 	case argument.valueType != param.validType:
 		if argValueType == String {
 			argVal = "\"" + argVal.(string) + "\""

--- a/parser.go
+++ b/parser.go
@@ -286,6 +286,11 @@ func collectValue(valueType *tokenType, value *any, until rune) {
 		if strings.ContainsAny(stringValue, "{}") {
 			checkInlineVars(&stringValue)
 		}
+	case char == '\'':
+		advance()
+		*valueType = RawString
+		*value = collectUntil('\'')
+		advance()
 	case char == '[':
 		advance()
 		*valueType = Arr

--- a/parser.go
+++ b/parser.go
@@ -198,9 +198,6 @@ func collectUntilIgnoreStrings(ch rune) string {
 		if char == '"' {
 			insideString = insideString && prev(1) == '\\'
 		}
-		if char == '\'' {
-			insideString = insideString && prev(1) == '\\'
-		}
 		collected.WriteRune(char)
 		advance()
 	}

--- a/parser.go
+++ b/parser.go
@@ -198,6 +198,9 @@ func collectUntilIgnoreStrings(ch rune) string {
 		if char == '"' {
 			insideString = insideString && prev(1) == '\\'
 		}
+		if char == '\'' {
+			insideString = insideString && prev(1) == '\\'
+		}
 		collected.WriteRune(char)
 		advance()
 	}

--- a/parser.go
+++ b/parser.go
@@ -292,7 +292,7 @@ func collectValue(valueType *tokenType, value *any, until rune) {
 	case char == '\'':
 		advance()
 		*valueType = RawString
-		*value = collectUntil('\'')
+		*value = collectRawString()
 		advance()
 	case char == '[':
 		advance()
@@ -1118,6 +1118,26 @@ func collectString() string {
 		advance()
 	}
 	advance()
+	return collection.String()
+}
+
+func collectRawString() string {
+	var collection strings.Builder
+	for char != -1 {
+		if char == '\\' && next(1) == '\'' {
+			collection.WriteRune('\'')
+			advanceTimes(2)
+			continue
+		}
+		if char == '\'' {
+			break
+		}
+
+		collection.WriteRune(char)
+		advance()
+	}
+	advance()
+
 	return collection.String()
 }
 

--- a/plist.go
+++ b/plist.go
@@ -181,6 +181,8 @@ func makeVariableValue(outputName *plistData, UUID *plistData, valueType tokenTy
 		makeBoolValue(outputName, UUID, value)
 	case String:
 		makeStringValue(outputName, UUID, value)
+	case RawString:
+		makeRawStringValue(outputName, UUID, value)
 	case Expression:
 		makeExpressionValue(outputName, UUID, value)
 	case Action:
@@ -209,6 +211,18 @@ func makeStringValue(outputName *plistData, UUID *plistData, value *any) {
 		*outputName,
 		*UUID,
 		attachmentValues("WFTextActionText", fmt.Sprintf("%s", *value), Text),
+	}))
+}
+
+func makeRawStringValue(outputName *plistData, UUID *plistData, value *any) {
+	appendPlist(makeStdAction("gettext", []plistData{
+		*outputName,
+		*UUID,
+		{
+			key:      "WFTextActionText",
+			dataType: Text,
+			value:    fmt.Sprintf("%s", *value),
+		},
 	}))
 }
 

--- a/tests/variables.cherri
+++ b/tests/variables.cherri
@@ -7,10 +7,11 @@ const immutable = 5
 @multiString = "Multiline
 string
 var"
+@rawString = 'not allowed inline variables, new lines, single quotes, etc. but i compile faster!'
 @arrayVar = ["item 1 {intVar}","item 2","item 3",5,{"key1":"value","key2":5,"key3":true}]
 @boolVarTrue = true
 @boolVarFalse = false
-@urlVar = url("https://apple.com","https://google.com")
+@urlVar = url('https://apple.com','https://google.com')
 @dateVar = date("October 5, 2022")
 @email = emailAddress("test@test.com")
 @phone = phoneNumber("(555) 555-5555")

--- a/tests/variables.cherri
+++ b/tests/variables.cherri
@@ -7,7 +7,7 @@ const immutable = 5
 @multiString = "Multiline
 string
 var"
-@rawString = 'not allowed inline variables, new lines, single quotes, etc. but i compile faster!'
+@rawString = 'i\'m not allowed inline variables, new lines, etc. but i compile faster!'
 @arrayVar = ["item 1 {intVar}","item 2","item 3",5,{"key1":"value","key2":5,"key3":true}]
 @boolVarTrue = true
 @boolVarFalse = false

--- a/token.go
+++ b/token.go
@@ -60,6 +60,7 @@ const (
 
 const (
 	String       tokenType = "text"
+	RawString    tokenType = "rawtext"
 	Integer      tokenType = "number"
 	Dict         tokenType = "dictionary"
 	Arr          tokenType = "array"


### PR DESCRIPTION
This implements a new type of string I'm calling a **raw string**. If you declare a string value with a single quote (`'`) instead of a double quote (`"`), this is defined as a raw string so the compiler will not check for inline variables and interpolate new lines, carriage returns, etc. as with standard strings. The parser will only collect characters until the ending single quote.

It does allow for the escaping of single quotes for sanity, however (e.g. "I don't need interpolation or inline variables, but I need a single quote for a contraction word like you're."). So it still interpolates that, but otherwise it just writes the runes to a string builder until it gets to an unescaped single quite.

So, as you can probably imagine, the advantage of raw strings is that they will compile much faster than standard strings if you do not need to use any of those features in a string value.

With a raw string, the parser does not need to...
- Interpolate the string (convert `\n` to a new line).
- Check for inline variables.
    - If so, check that the inline variable references are valid.

The property list generator doesn't need to...
- Check if the string contains inline variables to create the data structures Shortcuts are required for inline variables in text.