### PR TITLE
bugfix #55: Track bracket depth in object collection

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1207,7 +1207,7 @@ func collectDictionary() (dictionary interface{}) {
 
 func collectObject() string {
 	var jsonStr strings.Builder
-	var insideInnerObject = false
+	var innerObjectDepth = 0
 	var insideString = false
 	for char != -1 {
 		if char == '"' {
@@ -1221,12 +1221,12 @@ func collectObject() string {
 		}
 		if !insideString {
 			if char == '{' {
-				insideInnerObject = true
+				innerObjectDepth += 1
 			} else if char == '}' {
-				if !insideInnerObject {
+				if innerObjectDepth == 0 {
 					break
 				}
-				insideInnerObject = false
+				innerObjectDepth -= 1
 			}
 		}
 		jsonStr.WriteRune(char)


### PR DESCRIPTION
This PR fixes bug #55 by tracking bracket depth in object collection. The depth starts at 0, increases with every left bracket, decreases with every right bracket, and breaks if it finds a right bracket when there are no inner objects currently being tracked.