### PR TITLE
bugfix #62: Pass array variables to custom actions through their dictionary equivalent

### DIFF
--- a/custom_actions.go
+++ b/custom_actions.go
@@ -246,7 +246,18 @@ func makeCustomActionCall(identifier *string, arguments *[]actionArgument) (cust
 			case String:
 				argumentValue = fmt.Sprintf("\"%s\"", argumentValue)
 			case Variable:
-				argumentValue = fmt.Sprintf("\"{%s}\"", argumentValue)
+				var variableValue, found = getVariableValue(argumentValue)
+				if !found {
+					// Not sure what to do here
+					exit("Variable not found!")
+				}
+				if variableValue.valueType == Arr {
+					var jsonBytes, jsonErr = json.Marshal(variableValue.value)
+					handle(jsonErr)
+					argumentValue = fmt.Sprintf("{\"array\":%s}", string(jsonBytes))
+				} else {
+					argumentValue = fmt.Sprintf("\"{%s}\"", argumentValue)
+				}
 			case Arr:
 				var jsonBytes, jsonErr = json.Marshal(argument.value)
 				handle(jsonErr)

--- a/custom_actions.go
+++ b/custom_actions.go
@@ -7,9 +7,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/electrikmilk/args-parser"
 	"regexp"
 	"strings"
+
+	"github.com/electrikmilk/args-parser"
 )
 
 // customAction contains the collected declaration of a custom action.
@@ -248,8 +249,7 @@ func makeCustomActionCall(identifier *string, arguments *[]actionArgument) (cust
 			case Variable:
 				var variableValue, found = getVariableValue(argumentValue)
 				if !found {
-					// Not sure what to do here
-					exit("Variable not found!")
+					parserError(fmt.Sprintf("Variable not found: %s", argumentValue))
 				}
 				if variableValue.valueType == Arr {
 					var jsonBytes, jsonErr = json.Marshal(variableValue.value)

--- a/variables.go
+++ b/variables.go
@@ -84,3 +84,14 @@ func validReference(identifier string) bool {
 
 	return false
 }
+
+func getVariableValue(identifier string) (*variableValue, bool) {
+	if value, found := globals[identifier]; found {
+		return &value, true
+	}
+	if value, found := variables[identifier]; found {
+		return &value, true
+	}
+
+	return nil, false
+}


### PR DESCRIPTION
This PR fixes bug #62 by passing variables of the type array to custom actions by first turning them into JSON of form `{"array": [array]}`, as with array literals.

I am frankly not sure if this is the best way to do this, but it does work to fix the bug.

I didn't know what to do for the case where the variable isn't found because by this point, the program assumes all the variables have already been checked for existence.

I also took my best shot at the utility function for getting variables' values, but it may not be perfect.

Feedback is appreciated on this one.