### PR TITLE
Add optional album parameter to Save to Photo Album action

### DIFF
--- a/actions_std.go
+++ b/actions_std.go
@@ -7,12 +7,13 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/google/uuid"
 	"os"
 	"reflect"
 	"regexp"
 	"slices"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 // FIXME: Some of these actions have a value with a set list values for an arguments,
@@ -3259,15 +3260,13 @@ var actions = map[string]*actionDefinition{
 				validType: Variable,
 				key:       "WFInput",
 			},
-		},
-		addParams: func(_ []actionArgument) []plistData {
-			return []plistData{
-				{
-					key:      "WFCameraRollSelectedGroup",
-					dataType: Text,
-					value:    "Recents",
-				},
-			}
+			{
+				name:         "album",
+				validType:    String,
+				key:          "WFCameraRollSelectedGroup",
+				defaultValue: "Recents",
+				optional:     true,
+			},
 		},
 	},
 	"play": {


### PR DESCRIPTION
This PR adds an optional `album` parameter with the default value "Recents" to the [Save to Photo Album](https://cherrilang.org/language/standard/media.html#save-to-photo-album) action so that developers can use it to save photos to specific albums like the Shortcut app lets you do.

[Documentation PR](https://github.com/electrikmilk/cherrilang.org/pull/2)