### PR TITLE
bugfix #73: Fix custom actions to work in any language

### DIFF
--- a/custom_actions.go
+++ b/custom_actions.go
@@ -137,8 +137,10 @@ func makeCustomActionsHeader() {
 	var outputActionRegex = regexp.MustCompile(`(?:must)?[o|O]utput(?:OrClipboard)?\((.*?)\)`)
 	var customActionsHeader strings.Builder
 	customActionsHeader.WriteString("if ShortcutInput {\n")
+	customActionsHeader.WriteString("    @_cherri_empty_dictionary: dictionary\n")
+	customActionsHeader.WriteString("    const _cherri_dictionary_type_name = typeOf(_cherri_empty_dictionary)\n")
 	customActionsHeader.WriteString("    const _cherri_inputType = typeOf(ShortcutInput)\n")
-	customActionsHeader.WriteString("    if _cherri_inputType == \"Dictionary\" {\n")
+	customActionsHeader.WriteString("    if _cherri_inputType == _cherri_dictionary_type_name {\n")
 	customActionsHeader.WriteString("        const _cherri_input = getDictionary(ShortcutInput)\n")
 	customActionsHeader.WriteString("        const _cherri_identifier = getValue(_cherri_input, \"cherri_functions\")\n")
 	customActionsHeader.WriteString("        const _cherri_valid = number(_cherri_identifier)\n")


### PR DESCRIPTION
**issue**

resolve #73 

**description**

The bug was that when the “Dictionary” was localized according to the language setting, a wrong branch in the code for customAction occurred, resulting in an infinite loop.

This PR fixes it so that it works fine even if “Dictionary” is localized.
It works equally well in any language setting by taking the type of an empty dictionary variable and comparing it to it.