### PR TITLE
bugfix #75: Output Shortcut at `--output` path

### DIFF
--- a/args.go
+++ b/args.go
@@ -32,9 +32,11 @@ func init() {
 		Description: "Create plist file, print debug and stack traces.",
 	})
 	args.Register(args.Argument{
-		Name:        "output",
-		Short:       "o",
-		Description: "Set custom output file path.",
+		Name:         "output",
+		Short:        "o",
+		Description:  "Set custom output file path.",
+		DefaultValue: "",
+		ExpectsValue: true,
 	})
 	args.Register(args.Argument{
 		Name:        "import",

--- a/parser.go
+++ b/parser.go
@@ -7,14 +7,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/electrikmilk/args-parser"
-	"github.com/google/uuid"
 	"os"
 	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/electrikmilk/args-parser"
+	"github.com/google/uuid"
 )
 
 var idx int
@@ -634,7 +635,9 @@ func collectDefinition() {
 		if strings.Trim(workflowName, " \n\t") == "" {
 			parserError("Expected name")
 		}
-		outputPath = relativePath + workflowName + ".shortcut"
+		if !args.Using("output") {
+			outputPath = relativePath + workflowName + ".shortcut"
+		}
 	case tokenAhead(Color):
 		advance()
 		collectColorDefinition()

--- a/signing.go
+++ b/signing.go
@@ -8,12 +8,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/electrikmilk/args-parser"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/electrikmilk/args-parser"
 )
 
 var signFailed = false
@@ -131,7 +132,7 @@ func removeUnsigned() {
 	}
 
 	if args.Using("debug") {
-		fmt.Printf("Removing %s_unsigned.shortcut...", workflowName)
+		fmt.Printf("Removing %s%s...", workflowName, unsignedEnd)
 	}
 
 	removeErr := os.Remove(inputPath)


### PR DESCRIPTION
This PR fixes #75 by making the `--output` flag have a value and not resetting the output path to the name of the workflow when an `--output` path is set.

It also changes a hardcoded `_unsigned.shortcut` to the constant set to that value, juuuuuust in case it gets changed later.