### PR TITLE
bugfix #77: Fix error and debug line/columns

### DIFF
--- a/cherri_test.go
+++ b/cherri_test.go
@@ -7,11 +7,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/electrikmilk/args-parser"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/electrikmilk/args-parser"
 )
 
 var currentTest string
@@ -91,7 +92,7 @@ func resetParser() {
 	char = -1
 	idx = 0
 	lineIdx = 0
-	lineCharIdx = 0
+	lineCharIdx = -1
 	groupingUUIDs = map[int]string{}
 	groupingTypes = map[int]tokenType{}
 	groupingIdx = 0

--- a/copy_paste.go
+++ b/copy_paste.go
@@ -6,9 +6,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/electrikmilk/args-parser"
 	"regexp"
 	"strings"
+
+	"github.com/electrikmilk/args-parser"
 )
 
 var pasteables map[string]string
@@ -63,11 +64,6 @@ func collectCopy() {
 
 func pasteCopy() {
 	var identifier = collectIdentifier()
-	if char == '\n' {
-		idx--
-		lineIdx--
-		lineCharIdx = len(lines[lineIdx])
-	}
 	if contents, found := pasteables[identifier]; found {
 		lines[lineIdx] = contents
 	} else {

--- a/includes.go
+++ b/includes.go
@@ -6,10 +6,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/electrikmilk/args-parser"
 	"os"
 	"slices"
 	"strings"
+
+	"github.com/electrikmilk/args-parser"
 )
 
 // include is a data structure to track include statements.
@@ -78,7 +79,6 @@ func parseInclude() {
 	advance()
 
 	var includePath = collectRawString()
-	lineIdx--
 
 	if slices.Contains(included, includePath) {
 		parserError(fmt.Sprintf("File '%s' has already been included.", includePath))

--- a/output.go
+++ b/output.go
@@ -57,7 +57,7 @@ func openShortcut() {
 	handle(importErr)
 }
 
-func printChar(ch rune) {
+func printChar(ch rune, chLineIdx int, chLineCharIdx int) {
 	var currentChar string
 	switch ch {
 	case ' ':
@@ -71,7 +71,7 @@ func printChar(ch rune) {
 	default:
 		currentChar = string(ch)
 	}
-	fmt.Printf("%s %d:%d\n", currentChar, lineIdx+1, lineCharIdx+1)
+	fmt.Printf("%s %d:%d\n", currentChar, chLineIdx+1, chLineCharIdx+1)
 }
 
 type outputType int

--- a/output.go
+++ b/output.go
@@ -6,9 +6,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/electrikmilk/args-parser"
 	"os"
 	"os/exec"
+
+	"github.com/electrikmilk/args-parser"
 )
 
 // writeFile writes plist in bytes to filename.
@@ -70,7 +71,7 @@ func printChar(ch rune) {
 	default:
 		currentChar = string(ch)
 	}
-	fmt.Printf("%s %d:%d\n", currentChar, lineIdx+1, lineCharIdx)
+	fmt.Printf("%s %d:%d\n", currentChar, lineIdx+1, lineCharIdx+1)
 }
 
 type outputType int

--- a/parser.go
+++ b/parser.go
@@ -76,7 +76,7 @@ func initParse() {
 	char = -1
 	idx = -1
 	lineIdx = 0
-	lineCharIdx = 0
+	lineCharIdx = -1
 	chars = []rune{}
 	lines = []string{}
 	groupingUUIDs = map[int]string{}
@@ -1422,7 +1422,7 @@ func getChar(atIndex int) rune {
 
 func firstChar() {
 	lineIdx = 0
-	lineCharIdx = 0
+	lineCharIdx = -1
 	idx = -1
 	advance()
 }

--- a/parser.go
+++ b/parser.go
@@ -7,14 +7,15 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/electrikmilk/args-parser"
-	"github.com/google/uuid"
 	"os"
 	"regexp"
 	"slices"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/electrikmilk/args-parser"
+	"github.com/google/uuid"
 )
 
 var idx int
@@ -281,7 +282,6 @@ func collectVariableValue(constant bool, valueType *tokenType, value *any, coerc
 	collectValue(valueType, value, '\n')
 
 	if constant && (*valueType == Arr || *valueType == Variable) {
-		lineIdx--
 		parserError(fmt.Sprintf("Type %v values cannot be constants.", *valueType))
 	}
 	if *valueType == Question {
@@ -564,7 +564,6 @@ func collectVariable(constant bool) {
 		skipWhitespace()
 		collectType(&valueType, &value)
 	case constant:
-		lineIdx--
 		parserError("Constants must be initialized with a value.")
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -1309,19 +1309,19 @@ func collectAction(identifier *string) (value action) {
 
 // advance advances the character cursor.
 func advance() {
-	idx++
-	if len(chars) <= idx {
-		char = -1
-		return
-	}
-
-	char = chars[idx]
 	if char == '\n' {
 		lineCharIdx = 0
 		lineIdx++
 	} else {
 		lineCharIdx++
 	}
+
+	idx++
+	if len(chars) <= idx {
+		char = -1
+		return
+	}
+	char = chars[idx]
 }
 
 // advanceTimes advances the character cursor by `times`.

--- a/parser.go
+++ b/parser.go
@@ -111,16 +111,26 @@ func printParsingDebug() {
 
 	if idx != 0 {
 		fmt.Println("Previous Character:")
-		printChar(prev(1))
+		var prevChar = prev(1)
+		if prevChar != '\n' {
+			printChar(prevChar, lineIdx, lineCharIdx-1)
+		} else {
+			printChar(prevChar, lineIdx-1, len(lines[lineIdx-1]))
+		}
 	}
 
 	fmt.Println("\nCurrent Character:")
-	printChar(char)
+	printChar(char, lineIdx, lineCharIdx)
 	fmt.Print("\n")
 
 	if len(contents) > idx+1 {
 		fmt.Println("Next Character:")
-		printChar(next(1))
+		var nextChar = next(1)
+		if char != '\n' {
+			printChar(nextChar, lineIdx, lineCharIdx+1)
+		} else {
+			printChar(nextChar, lineIdx+1, 0)
+		}
 		fmt.Print("\n")
 	}
 


### PR DESCRIPTION
This PR fixes #77 by:

1. Changing `lineCharIdx` to be fully 0-indexed: Currently, it's technically 0-indexed, but it gets set to 1 immediately when parsing starts because `advance()` gets called to load `char`. On subsequent lines, it gets set to 0, but it gets reset when advancing to a newline character.
2. Changing to a new line after advancing from a newline character, not advancing to a newline character: In the error in my issue, the parser error is called after the action call is consumed and the parser gets advanced to the newline, which increments the line counter and resets the column counter. I also removed some `lineIdx--` calls that I think were put in place to decrement the line counter after advancing to a newline when consuming some identifiers.
3. Making previous/current/next character positions variable: They were all the same before - now they're based on the previous character being a newline or not.

The part I'm most unsure of is the if statement in the copy-paste section - I deleted that because it didn't seem to do anything useful with the changes above, but I don't fully understand why it was there in the first place, so if you could review that for me, I would be grateful.

Thank you!

The debug output of the example looks like this now:

```
Parsing test_errors.cherri...
Parsing includes...
### INCLUDES ###

## INCLUDED ##
[]

## INCLUDES MAP ##
[]

Done.


Invalid value 0 (number) for argument 'output' (text).
output(text output)

----- test_errors.cherri:1:10
1 | output(0)
             ^
2 | alert("Test!")
-----

###################
#   DEBUG PANIC   #
###################

### PARSING ###

Previous Character:
) 1:9

Current Character:
LF 1:10

Next Character:
a 2:1

Current Line:
output(0)
## TOKENS ##

## DEFINITIONS ##
Name: test_errors
Color: -1263359489
Glyph: 61440
Inputs: []
Outputs: []
Workflows: []
No Input: { []}
macOS Only: false
Client Version: 3036.0.4.2
iOS Version: 18.0

## VARIABLES ##

## MENUS ##
map[]

## IMPORT QUESTIONS ##
map[]

### PLIST GEN ###

## UUIDS ##
map[]

### CUSTOM ACTIONS ###

### INCLUDES ###

## INCLUDED ##
[]

## INCLUDES MAP ##
[]

#############################################################
```