### PR TITLE
bugfix #71: Fix modifying variables using other variables

### DIFF
--- a/plist.go
+++ b/plist.go
@@ -163,8 +163,7 @@ func makeVariableAction(token *token, varUUID *string) {
 		dataType: Text,
 		value:    token.ident,
 	}
-	if token.typeof != Var &&
-		(token.typeof == AddTo || token.typeof == SubFrom || token.typeof == MultiplyBy || token.typeof == DivideBy) &&
+	if (token.typeof == AddTo || token.typeof == SubFrom || token.typeof == MultiplyBy || token.typeof == DivideBy) &&
 		token.valueType != Arr &&
 		variables[token.ident].valueType != Arr {
 		variableValueModifier(token, &outputName, &UUID)

--- a/plistgen.go
+++ b/plistgen.go
@@ -6,10 +6,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/electrikmilk/args-parser"
-	"github.com/google/uuid"
 	"reflect"
 	"strings"
+
+	"github.com/electrikmilk/args-parser"
+	"github.com/google/uuid"
 )
 
 const header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n"
@@ -219,7 +220,7 @@ func plistVariable(t *token) {
 		makeVariableAction(t, &varUUID)
 		uuids[t.ident] = varUUID
 		if t.valueType != Arr {
-			if t.valueType == Variable {
+			if t.typeof == Var && t.valueType == Variable {
 				setVariableParams = append(setVariableParams, variablePlistValue("WFInput", t.value.(string), t.ident))
 			} else {
 				setVariableParams = append(setVariableParams, inputValue("WFInput", t.ident, varUUID))

--- a/token.go
+++ b/token.go
@@ -16,7 +16,6 @@ type token struct {
 var tokens []token
 
 /* Keywords */
-
 const (
 	Var            tokenType = "variable"
 	Constant       tokenType = "const"
@@ -38,7 +37,6 @@ const (
 )
 
 /* Definitions */
-
 const (
 	Name    tokenType = "name"
 	Color   tokenType = "color"
@@ -52,7 +50,6 @@ const (
 )
 
 /* No Inputs */
-
 const (
 	StopWith     tokenType = "stopwith"
 	AskFor       tokenType = "askfor"
@@ -60,7 +57,6 @@ const (
 )
 
 /* Types */
-
 const (
 	String       tokenType = "text"
 	RawString    tokenType = "rawtext"
@@ -81,7 +77,6 @@ const (
 )
 
 /* Operators */
-
 const (
 	Set            tokenType = "="
 	AddTo          tokenType = "+="


### PR DESCRIPTION
This one's a quick fix but it was a doozy to understand what was going wrong!

When a token is processed where a variable is set or modified in some way, `plistVariable` is called:
https://github.com/electrikmilk/cherri/blob/9798d1bb94d8b9fd6373dc176b7a79c5e1d49acd/plistgen.go#L168-L175

`plistVariable` calls `makeVariableAction` if the variable's value isn't nothing:
https://github.com/electrikmilk/cherri/blob/9798d1bb94d8b9fd6373dc176b7a79c5e1d49acd/plistgen.go#L217-L219

And if the token modifies the variable and doesn't set it straight to something (and isn't an array), `makeVariableAction` calls `variableValueModifier`:
https://github.com/electrikmilk/cherri/blob/9798d1bb94d8b9fd6373dc176b7a79c5e1d49acd/plist.go#L166-L170

`variableValueModifier` adds a new action call, regardless of whether the modified variable is an integer or a string, with the name `outputName`:
https://github.com/electrikmilk/cherri/blob/9798d1bb94d8b9fd6373dc176b7a79c5e1d49acd/plist.go#L343-L344

But what is `outputName`? Back in `makeVariableAction`, we can see it has the `CustomOutputName` of `token.ident`, which is the variable name (in the statement `@str += var`, think `"str"`):
https://github.com/electrikmilk/cherri/blob/9798d1bb94d8b9fd6373dc176b7a79c5e1d49acd/plist.go#L161-L165

And in `plistVariable`, if the variable's value type is not an array and is a variable, it sets the input to not the variable name, but the variable value's name (in `@str += var`, think `"var"`):
https://github.com/electrikmilk/cherri/blob/9798d1bb94d8b9fd6373dc176b7a79c5e1d49acd/plistgen.go#L221-L226

This works great in cases where integer/string variables are being set straight, but when they're being modified, the action skips over the action that was just created to mix the 2 variables and goes straight to the variable it's being set too, hence `str` being set to `var` instead of `var` being appended to `str`!

Whew! I am now released from my quest and can go to bed.

This PR also:
- Removes an unnecessary conditional in `makeVariableAction` (`token.typeof != Var` will always be true if it's equal to any one of the other 4 listed right after)
- Reorders imports (thanks IDE)
- Removes newlines in `token.go` to make the token group descriptions show up in my IDE

One thing I noticed while traipsing through all this code is that `Var`, `Variable`, and `Set` all have very similar meanings, but seem to be supposed to be used in different ways. I may or may not try to reorganize them.