### PR TITLE
Implement multiple conditions to conditionals

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -115,14 +115,14 @@ var languages = []string{
 
 /* Conditionals */
 
+type WFConditions struct {
+	conditions                    []condition
+	WFActionParameterFilterPrefix int
+}
+
 type condition struct {
-	variableOneType    tokenType
-	variableOneValue   any
-	condition          int
-	variableTwoType    tokenType
-	variableTwoValue   any
-	variableThreeType  tokenType
-	variableThreeValue any
+	condition int
+	arguments []actionArgument
 }
 
 var conditions = map[tokenType]int{
@@ -139,6 +139,11 @@ var conditions = map[tokenType]int{
 	LessThan:       0,
 	LessOrEqual:    1,
 	Between:        1003,
+}
+
+var conditionFilterPrefixes = map[tokenType]int{
+	Or:  0,
+	And: 1,
 }
 
 var allowedConditionalTypes = map[tokenType][]tokenType{

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -298,15 +298,13 @@ func makeConditions(wfConditions *WFConditions) map[string]any {
 		filterTemplates = append(filterTemplates, conditionParams)
 	}
 
-	var conditionParams = map[string]any{
-		"WFSerializationType": "WFContentPredicateTableTemplate",
+	return map[string]any{
 		"Value": map[string]any{
 			"WFActionParameterFilterPrefix":    wfConditions.WFActionParameterFilterPrefix,
 			"WFActionParameterFilterTemplates": filterTemplates,
 		},
+		"WFSerializationType": "WFContentPredicateTableTemplate",
 	}
-
-	return conditionParams
 }
 
 func makeMenuAction(t *token) {

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -244,8 +244,28 @@ func makeConditionalAction(t *token) {
 	case If:
 		conditionalParams["WFControlFlowMode"] = startStatement
 
-		var cond = t.value.(WFConditions)
-		conditionalParams["WFConditions"] = makeConditions(&cond)
+		if iosVersion < 18 {
+			var cond = t.value.(WFConditions)
+			var firstCondition = cond.conditions[0]
+			var firstArg = firstCondition.arguments[0]
+			conditionalParams["WFInput"] = map[string]any{
+				"Type":     "Variable",
+				"Variable": variableValue(firstArg.value.(varValue)),
+			}
+			if len(firstCondition.arguments) > 1 {
+				var secondArg = firstCondition.arguments[1]
+				conditionalParameter("", conditionalParams, &secondArg.valueType, secondArg.value)
+			}
+			if len(firstCondition.arguments) > 2 {
+				var thirdArg = firstCondition.arguments[2]
+				conditionalParameter("WFAnotherNumber", conditionalParams, &thirdArg.valueType, thirdArg.value)
+			}
+			conditionalParams["WFCondition"] = firstCondition.condition
+			conditionalParams["WFControlFlowMode"] = startStatement
+		} else {
+			var cond = t.value.(WFConditions)
+			conditionalParams["WFConditions"] = makeConditions(&cond)
+		}
 	case Else:
 		conditionalParams["WFControlFlowMode"] = statementPart
 	case EndClosure:

--- a/tests/conditionals.cherri
+++ b/tests/conditionals.cherri
@@ -27,6 +27,11 @@ if textVar endsWith "2" {}
 if textVar endsWith textVar2 {}
 if intVar <> 5 6 {} // between
 
+// multiple conditions
+if intVar && intVar == 5 {}
+if intVar || textVar {}
+if intVar == 5 && textVar == "string" {}
+
 // nesting...
 if intVar > 5 {
     @intvar3 = 5

--- a/token.go
+++ b/token.go
@@ -103,4 +103,6 @@ const (
 	LeftBrace      tokenType = "{"
 	RightBrace     tokenType = "}"
 	Colon          tokenType = ":"
+	And            tokenType = "&&"
+	Or             tokenType = "||"
 )


### PR DESCRIPTION
This MR now allows for this:

```ruby
if int == 5 && text == "test" {
    // ...
}
```

The only limitation is your Shortcuts platform version and the fact that they are more like a filter, and that means that it's either all (and) or any (or).

This includes the legacy version of conditions; just use `#define version 17` or any version lower than 18.

This also generally improves the way we handle conditionals.