### PR TITLE
#93: Refactor and Fix Raw Actions

### DIFF
--- a/actions_std.go
+++ b/actions_std.go
@@ -6247,7 +6247,14 @@ func defineRawAction() {
 				return map[string]any{}
 			}
 
-			return getArgValue(args[1]).(map[string]interface{})
+			var params = getArgValue(args[1]).(map[string]interface{})
+			for key, value := range params {
+				if reflect.TypeOf(value).Kind() == reflect.String {
+					params[key] = attachmentValues(value.(string))
+				}
+			}
+
+			return params
 		},
 	}
 }

--- a/actions_std.go
+++ b/actions_std.go
@@ -6226,8 +6226,6 @@ var actions = map[string]*actionDefinition{
 	},
 }
 
-var plistTypes = map[string]string{"string": "", "integer": "", "boolean": "", "array": "", "dict": "", "real": ""}
-
 func defineRawAction() {
 	actions["rawAction"] = &actionDefinition{
 		parameters: []parameterDefinition{
@@ -6238,55 +6236,18 @@ func defineRawAction() {
 			{
 				name:      "parameters",
 				optional:  true,
-				validType: Arr,
+				validType: Dict,
 			},
 		},
 		check: func(args []actionArgument, _ *actionDefinition) {
 			actions["rawAction"].overrideIdentifier = getArgValue(args[0]).(string)
-
-			if len(args) > 1 {
-				for _, parameterDefinitions := range getArgValue(args[1]).([]interface{}) {
-					var definitions = parameterDefinitions.(map[string]interface{})
-					if definitions["type"] != nil {
-						var paramKey = definitions["key"]
-						var paramType = definitions["type"].(string)
-						var paramValue = definitions["value"].(string)
-						if _, found := plistTypes[paramType]; !found {
-							var list = makeKeyList("Available plist types:", plistTypes, paramValue)
-							parserError(fmt.Sprintf("Raw action parameter '%s' type '%s' is not a plist type.\n\n%s", paramKey, paramType, list))
-						}
-					}
-				}
-			}
 		},
 		make: func(args []actionArgument) map[string]any {
-			var params = make(map[string]any)
 			if len(args) == 1 {
-				return params
-			}
-			for _, parameterDefinitions := range getArgValue(args[1]).([]interface{}) {
-				var paramKey string
-				var paramType dataType
-				var rawValue any
-				for key, value := range parameterDefinitions.(map[string]interface{}) {
-					switch key {
-					case "key":
-						paramKey = value.(string)
-					case "type":
-						paramType = dataType(value.(string))
-					case "value":
-						rawValue = value
-					}
-				}
-
-				var tokenType = convertDataTypeToTokenType(paramType)
-				params[paramKey] = paramValue(actionArgument{
-					valueType: tokenType,
-					value:     rawValue,
-				}, tokenType)
+				return map[string]any{}
 			}
 
-			return params
+			return getArgValue(args[1]).(map[string]interface{})
 		},
 	}
 }

--- a/decompile.go
+++ b/decompile.go
@@ -966,7 +966,7 @@ func decompAttachmentString(attachmentString *string, attachments map[string]int
 
 	if (!decompilingDictionary && !decompilingText) && len(attachments) == 1 && originalString == ObjectReplaceCharStr {
 		*attachmentString = strings.Trim(*attachmentString, "{}")
-	} else {
+	} else if strings.Contains("\"", *attachmentString) {
 		*attachmentString = fmt.Sprintf("\"%s\"", *attachmentString)
 	}
 }
@@ -1189,7 +1189,9 @@ func makeRawAction(action *ShortcutAction) string {
 func processRawParameters(params map[string]any) map[string]any {
 	for key, value := range params {
 		if reflect.TypeOf(value).Kind() == reflect.Map {
+			decompilingDictionary = true
 			params[key] = decompValueObject(value.(map[string]interface{}))
+			decompilingDictionary = false
 		}
 	}
 

--- a/decompile.go
+++ b/decompile.go
@@ -1173,41 +1173,27 @@ func makeRawAction(action *ShortcutAction) string {
 			onlyOutputNameParam = found
 		}
 	}
-	if paramsSize > 1 && (!onlyUUIDParam && !onlyOutputNameParam) {
-		tabLevel++
-		rawActionCode.WriteString(", [\n")
-		rawActionCode.WriteString(tabbedLine("{\n"))
-		var index = 0
-		for key, param := range action.WFWorkflowActionParameters {
-			index++
+	if paramsSize != 0 && (!onlyUUIDParam && !onlyOutputNameParam) {
+		rawActionCode.WriteString(", ")
 
-			if key == UUID || key == "CustomOutputName" {
-				continue
-			}
-
-			rawActionCode.WriteString(strings.Repeat("\t", tabLevel+1))
-			rawActionCode.WriteString(fmt.Sprintf("\"%s\": ", key))
-
-			var value = decompValue(param)
-			if !strings.Contains(value, "\"") {
-				value = fmt.Sprintf("\"{%s}\"", value)
-			}
-			rawActionCode.WriteString(value)
-
-			if index < paramsSize {
-				rawActionCode.WriteString(", ")
-			}
-			rawActionCode.WriteRune('\n')
-		}
-
-		rawActionCode.WriteString(tabbedLine("}\n"))
-		tabLevel--
-		rawActionCode.WriteString(tabbedLine("])"))
-	} else {
-		rawActionCode.WriteRune(')')
+		var rawParams = processRawParameters(action.WFWorkflowActionParameters)
+		var jb, jsonErr = json.MarshalIndent(rawParams, strings.Repeat("\t", tabLevel), "\t")
+		handle(jsonErr)
+		rawActionCode.WriteString(string(jb))
 	}
+	rawActionCode.WriteRune(')')
 
 	return rawActionCode.String()
+}
+
+func processRawParameters(params map[string]any) map[string]any {
+	for key, value := range params {
+		if reflect.TypeOf(value).Kind() == reflect.Map {
+			params[key] = decompValueObject(value.(map[string]interface{}))
+		}
+	}
+
+	return params
 }
 
 func matchAction(action *ShortcutAction) (name string, definition actionDefinition) {

--- a/tests/raw_action.cherri
+++ b/tests/raw_action.cherri
@@ -1,12 +1,4 @@
-rawAction("is.workflow.actions.alert", [
-    {
-        "key": "WFAlertActionMessage",
-        "type": "string",
-        "value": "Hello, world!"
-    },
-    {
-        "key": "WFAlertActionTitle",
-        "type": "string",
-        "value": "Alert"
-    }
-])
+rawAction("is.workflow.actions.alert", {
+    "WFAlertActionMessage": "Hello, world!"
+    "WFAlertActionTitle": "Alert"
+})

--- a/tests/raw_action.cherri
+++ b/tests/raw_action.cherri
@@ -1,4 +1,4 @@
 rawAction("is.workflow.actions.alert", {
-    "WFAlertActionMessage": "Hello, world!"
+    "WFAlertActionMessage": "Hello, world!",
     "WFAlertActionTitle": "Alert"
 })


### PR DESCRIPTION
This is to fix bugs with and improve raw actions.

This MR refactors raw actions to allow for any type of value for each parameter.

**Before**

```javascript
rawAction("is.workflow.actions.documentpicker.save", [
  {
    "key": "WFAskWhereToSave",
    "type": "boolean",
    "value": true
  },
  {
    "key": "WFSaveFileOverwrite",
    "type": "boolean",
    "value": false
  }
])
```

**After**

```javascript
rawAction("is.workflow.actions.documentpicker.save", {
    "WFAskWhereToSave": true,
    "WFSaveFileOverwrite": false
})
```

This became possible now that we use a plist marshaller, having them as strings only before was to ensure the value would be translated properly, but now there is no need to worry about this, as we can just pass the dictionary of parameters through.

### Decompilation

This also fixes decompilation, but mostly just to allow any type value. We will still decompile the value of each parameter, but only if it's an object. This also unfortunately removes the type check of the value, as trying to map that between Go and Shortcuts seems silly for now, just be careful.

I also noticed we just decompiled the params without our format of dictionaries in arrays, so this change was required to compile the decompilations. Both compilation and decompilation raw actions are now in sync with this change.