### PR TITLE
Move some standard actions to standard action definitions in embedded Cherri files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ src/aml
 
 # Tests
 *.cherri
+!/actions/*.cherri
 !/tests/*.cherri
 /tests/*_decompiled.plist
 !stdlib.cherri

--- a/action.go
+++ b/action.go
@@ -6,16 +6,23 @@ package main
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"math"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
+
+	"github.com/electrikmilk/args-parser"
 )
 
 //go:embed stdlib.cherri
 var stdLib embed.FS
+
+//go:embed actions
+var stdActions embed.FS
 
 // currentAction holds the current action definition between functions.
 var currentAction actionDefinition

--- a/action.go
+++ b/action.go
@@ -114,15 +114,15 @@ func undefinable() bool {
 func makeAction(arguments []actionArgument, reference *map[string]any) {
 	actionIndex++
 	// Determine identifier
-	var ident = getActionIdentifier()
+	var ident = getFullActionIdentifier()
 	// Determine parameters
 	var params = getActionParameters(arguments)
 	// Additionally add the output name and UUID of this action if provided
 	addAction(ident, attachReferenceToParams(&params, reference))
 }
 
-// getActionIdentifier determines the identifier of currentAction.
-func getActionIdentifier() (ident string) {
+// getFullActionIdentifier determines the full identifier of currentAction.
+func getFullActionIdentifier() (ident string) {
 	if currentAction.overrideIdentifier != "" {
 		return currentAction.overrideIdentifier
 	}
@@ -135,6 +135,19 @@ func getActionIdentifier() (ident string) {
 		ident = fmt.Sprintf("%s.%s", ident, currentAction.identifier)
 	} else {
 		ident = fmt.Sprintf("%s.%s", ident, strings.ToLower(currentActionIdentifier))
+	}
+	return
+}
+
+// getActionIdentifier determines the identifier of currentAction.
+func getActionIdentifier() (ident string) {
+	if currentAction.appIdentifier != "" {
+		ident = fmt.Sprintf("%s.", currentAction.appIdentifier)
+	}
+	if currentAction.identifier != "" {
+		ident = fmt.Sprintf("%s%s", ident, currentAction.identifier)
+	} else {
+		ident = fmt.Sprintf("%s%s", ident, strings.ToLower(currentActionIdentifier))
 	}
 	return
 }

--- a/action.go
+++ b/action.go
@@ -606,7 +606,7 @@ func generateActionParamDefinition(param parameterDefinition) string {
 	}
 	definition.WriteString(param.name)
 
-	if param.key != "" {
+	if param.key != "" && param.key != param.name {
 		definition.WriteString(fmt.Sprintf(": '%s'", param.key))
 	}
 
@@ -785,6 +785,8 @@ func collectParameterDefinitions() (arguments []parameterDefinition) {
 			}
 			advance()
 			parameterKey = collectRawString()
+		} else {
+			parameterKey = identifier
 		}
 
 		skipWhitespace()

--- a/action.go
+++ b/action.go
@@ -85,6 +85,7 @@ type actionDefinition struct {
 	minVersion         float64
 	maxVersion         float64
 	setKey             string
+	builtin            bool // builtin is based on if the action was in the actions map when it was first initialized.
 }
 
 // libraryDefinition defines a 3rd-party actions library that can be imported using the `#import` syntax.

--- a/action.go
+++ b/action.go
@@ -109,15 +109,15 @@ func setCurrentAction(identifier string, definition *actionDefinition) {
 func makeAction(arguments []actionArgument, reference *map[string]any) {
 	actionIndex++
 	// Determine identifier
-	var ident = actionIdentifier()
+	var ident = getActionIdentifier()
 	// Determine parameters
-	var params = actionParameters(arguments)
+	var params = getActionParameters(arguments)
 	// Additionally add the output name and UUID of this action if provided
 	addAction(ident, attachReferenceToParams(&params, reference))
 }
 
-// actionIdentifier determines the identifier of currentAction.
-func actionIdentifier() (ident string) {
+// getActionIdentifier determines the identifier of currentAction.
+func getActionIdentifier() (ident string) {
 	if currentAction.overrideIdentifier != "" {
 		return currentAction.overrideIdentifier
 	}
@@ -136,8 +136,8 @@ func actionIdentifier() (ident string) {
 
 var emptyAppIntent = appIntent{}
 
-// actionParameters creates the actions' parameters by injecting the values of the arguments into the defined parameters.
-func actionParameters(arguments []actionArgument) map[string]any {
+// getActionParameters creates the actions' parameters by injecting the values of the arguments into the defined parameters.
+func getActionParameters(arguments []actionArgument) map[string]any {
 	var params = make(map[string]any)
 	if currentAction.addParams != nil {
 		maps.Copy(params, currentAction.addParams(arguments))

--- a/actions/dropbox.cherri
+++ b/actions/dropbox.cherri
@@ -1,0 +1,6 @@
+#define action 'dropbox.savefile' saveToDropbox(
+    variable file: 'WFInput',
+    text path: 'WFFileDestinationPath',
+    bool ?askToSave: 'WFAskWhereToSave' = true
+    bool ?overwrite: 'WFSaveFileOverwrite' = false
+)

--- a/actions/dropbox.cherri
+++ b/actions/dropbox.cherri
@@ -1,6 +1,14 @@
 #define action 'dropbox.savefile' saveToDropbox(
     variable file: 'WFInput',
     text path: 'WFFileDestinationPath',
-    bool ?askToSave: 'WFAskWhereToSave' = true
     bool ?overwrite: 'WFSaveFileOverwrite' = false
-)
+) {
+     "WFAskWhereToSave": false
+}
+
+#define action 'dropbox.savefile' saveToDropboxPrompt(
+    variable file: 'WFInput',
+    bool ?overwrite: 'WFSaveFileOverwrite' = false
+) {
+    "WFAskWhereToSave": true
+}

--- a/cherri_test.go
+++ b/cherri_test.go
@@ -81,14 +81,6 @@ func TestDecomp(t *testing.T) {
 	fmt.Print(ansi("✅  PASSED", green, bold) + "\n\n")
 }
 
-func TestActionList(_ *testing.T) {
-	defineToggleSetActions()
-	defineRawAction()
-	for identifier := range actions {
-		fmt.Println("{label: '" + identifier + "', type: 'function', detail: 'action'},")
-	}
-}
-
 func TestActionSearch(_ *testing.T) {
 	args.Args["action"] = "replaceText"
 	actionsSearch()

--- a/copy_paste.go
+++ b/copy_paste.go
@@ -49,7 +49,7 @@ func parseCopyPastes() {
 }
 
 func collectCopy() {
-	var startLine = lineIdx
+	var lineRef = newLineReference()
 	var identifier = collectIdentifier()
 
 	if _, found := pasteables[identifier]; found {
@@ -60,9 +60,7 @@ func collectCopy() {
 	advance()
 	var contents = collectObject()
 
-	for i := startLine; i <= lineIdx; i++ {
-		lines[i] = ""
-	}
+	lineRef.replaceLines()
 
 	pasteables[identifier] = strings.TrimSpace(contents)
 }

--- a/custom_actions.go
+++ b/custom_actions.go
@@ -81,7 +81,7 @@ func isUsingCustomActions() bool {
 }
 
 func collectCustomActionDefinition() {
-	var startLine = lineIdx
+	var lineRef = newLineReference()
 	var identifier, arguments, outputType = collectActionDefinition('{')
 
 	advanceUntilExpect('{', 3)
@@ -89,9 +89,7 @@ func collectCustomActionDefinition() {
 
 	var body = strings.TrimSpace(collectObject())
 
-	for i := startLine; i <= lineIdx; i++ {
-		lines[i] = ""
-	}
+	lineRef.replaceLines()
 
 	customActions[identifier] = &customAction{
 		definition: actionDefinition{

--- a/custom_actions.go
+++ b/custom_actions.go
@@ -25,7 +25,7 @@ type customAction struct {
 // customActions is a map of all the custom actions that have been defined.
 var customActions map[string]*customAction
 
-// handleCustomActions parses defined actions and checks their usage.
+// handleCustomActions parses defined custom actions and checks their usage.
 func handleCustomActions() {
 	if !regexp.MustCompile(`action (.*?)\((.*?)\)`).MatchString(contents) {
 		return

--- a/includes.go
+++ b/includes.go
@@ -107,7 +107,7 @@ func parseInclude() {
 			parserError(fmt.Sprintf("Undefined actions include '%s'.", actionCat))
 		}
 	} else if includePath == "stdlib" {
-		includeFileBytes, includeReadErr = stdActions.ReadFile("stdlib.cherri")
+		includeFileBytes, includeReadErr = stdLib.ReadFile("stdlib.cherri")
 	} else {
 		if !strings.Contains(includePath, "..") {
 			includePath = relativePath + includePath

--- a/includes.go
+++ b/includes.go
@@ -100,8 +100,14 @@ func parseInclude() {
 
 	var includeFileBytes []byte
 	var includeReadErr error
-	if includePath == "stdlib" {
-		includeFileBytes, includeReadErr = stdLib.ReadFile("stdlib.cherri")
+	if startsWith("actions", includePath) && strings.Contains(includePath, "/") {
+		var actionCat = end(strings.Split(includePath, "/"))
+		includeFileBytes, includeReadErr = stdActions.ReadFile(fmt.Sprintf("actions/%s.cherri", actionCat))
+		if includeReadErr != nil {
+			parserError(fmt.Sprintf("Undefined actions include '%s'.", actionCat))
+		}
+	} else if includePath == "stdlib" {
+		includeFileBytes, includeReadErr = stdActions.ReadFile("stdlib.cherri")
 	} else {
 		if !strings.Contains(includePath, "..") {
 			includePath = relativePath + includePath

--- a/main.go
+++ b/main.go
@@ -47,8 +47,13 @@ func main() {
 
 	if args.Using("action") {
 		if args.Value("action") == "" {
+			defineRawAction()
+			defineToggleSetActions()
 			for identifier, definition := range actions {
 				setCurrentAction(identifier, definition)
+				if undefinable() {
+					continue
+				}
 				fmt.Println(generateActionDefinition(parameterDefinition{}, true, true))
 			}
 		} else {

--- a/main.go
+++ b/main.go
@@ -50,7 +50,6 @@ func main() {
 			for identifier, definition := range actions {
 				setCurrentAction(identifier, definition)
 				fmt.Println(generateActionDefinition(parameterDefinition{}, true, true))
-				fmt.Print("\n---\n\n")
 			}
 		} else {
 			actionsSearch()

--- a/parser.go
+++ b/parser.go
@@ -98,9 +98,16 @@ func initParse() {
 	}
 }
 
+func markBuiltins() {
+	for _, action := range actions {
+		action.builtin = true
+	}
+}
+
 func preParse() {
 	preParsing = true
 
+	markBuiltins()
 	defineRawAction()
 	waitFor(
 		defineToggleSetActions,

--- a/parser.go
+++ b/parser.go
@@ -454,6 +454,8 @@ func collectReference(valueType *tokenType, value *any, until *rune) {
 }
 
 func collectEnumeration() {
+	var lineRef = newLineReference()
+
 	advance()
 	if enumerations == nil {
 		enumerations = make(map[string][]string)
@@ -482,6 +484,8 @@ func collectEnumeration() {
 			advance()
 		}
 	}
+
+	lineRef.replaceLines()
 
 	enumerations[identifier] = enumeration
 	advance()

--- a/parser.go
+++ b/parser.go
@@ -42,6 +42,22 @@ func resetParse() {
 	firstChar()
 }
 
+type lineReference struct {
+	start int
+}
+
+// Creates a lineReference with the current lineIdx.
+func newLineReference() lineReference {
+	return lineReference{start: lineIdx}
+}
+
+// replaceLines replaces lines starting at startLine to prevent something from being parsed twice.
+func (lineRef *lineReference) replaceLines() {
+	for i := lineRef.start; i <= lineIdx; i++ {
+		lines[i] = ""
+	}
+}
+
 func initParse() {
 	if args.Using("debug") {
 		fmt.Printf("Parsing %s...\n", filename)
@@ -435,6 +451,8 @@ func collectReference(valueType *tokenType, value *any, until *rune) {
 }
 
 func collectEnumeration() {
+	var lineRef = newLineReference()
+
 	advance()
 	if enumerations == nil {
 		enumerations = make(map[string][]string)
@@ -463,6 +481,8 @@ func collectEnumeration() {
 			advance()
 		}
 	}
+
+	lineRef.replaceLines()
 
 	enumerations[identifier] = enumeration
 	advance()

--- a/tests/custom_action.cherri
+++ b/tests/custom_action.cherri
@@ -34,7 +34,7 @@ action saveFileToDropbox(text path, bool ?overwrite = false): bool {
 
 #define action 'dropbox.savefile' saveToDropboxPrompt(variable file: 'WFInput')
 
-#define action 'dropbox.savefile' saveToDropbox(
+#define action 'dropbox.savefile' saveToDropboxTest(
     variable file: 'WFInput',
     text path: 'WFFileDestinationPath',
     bool ?overwrite: 'WFSaveFileOverwrite' = false

--- a/tests/custom_action.cherri
+++ b/tests/custom_action.cherri
@@ -43,4 +43,4 @@ action saveFileToDropbox(text path, bool ?overwrite = false): bool {
 }
 
 @file = selectFile()
-saveToDropbox(file, '/folder/file.txt')
+saveToDropboxTest(file, '/folder/file.txt')

--- a/tests/custom_action.cherri
+++ b/tests/custom_action.cherri
@@ -32,7 +32,7 @@ action saveFileToDropbox(text path, bool ?overwrite = false): bool {
     output("{true}")
 }
 
-#define action 'dropbox.savefile' saveToDropboxPrompt(variable file: 'WFInput')
+#define action 'dropbox.savefile' saveToDropboxPromptTest(variable file: 'WFInput')
 
 #define action 'dropbox.savefile' saveToDropboxTest(
     variable file: 'WFInput',

--- a/tests/include-actions.cherri
+++ b/tests/include-actions.cherri
@@ -1,0 +1,4 @@
+#include 'actions/dropbox'
+
+@file = selectFile()
+saveToDropboxPrompt(file)


### PR DESCRIPTION
I want to start this off with an acknowledgement of the fact that not all actions will be able to be defined like this.

But for the actions that can, and I've modified the full actions search output to allow for this, there is a significant amount of actions we could manage in Cherri itself and automatically import.

We can organize these similar to the documentation with some exceptions because we will always include the base files and no one will need to specifically include these files.

The format however of includes, `#include 'actions/web'` can be used to have additional libraries bundled with the compiler but not loaded automatically into memory. For instance, we've never had the dropbox actions, etc because they're not standard and you need account access, but with this we could have an include that defines those actions for a 3rd party app.  I think we'll keep our library implementation just in case we need it, but this will be way easier than that to implement 3rd party app actions.

I filtered down the action search output to actions we can actually define outside of the compiler and the action will continue to work and modified it to output the enumerations instead of lists.

I now have an actions.cherri file I am pruning into separate files. I am going through these so that the code is more readable and actions are grouped together.

This will make it a lot easier to contribute actions to the compiler.