### PR TITLE
bugfix #97: Add ability to specify path in home folder

### DIFF
--- a/actions_std.go
+++ b/actions_std.go
@@ -1517,8 +1517,7 @@ var actions = map[string]*actionDefinition{
 		parameters: []parameterDefinition{
 			{
 				name:      "folder",
-				validType: Variable,
-				key:       "WFFile",
+				validType: String,
 			},
 			{
 				name:      "path",
@@ -1532,6 +1531,30 @@ var actions = map[string]*actionDefinition{
 				defaultValue: true,
 				optional:     true,
 			},
+		},
+		addParams: func(args []actionArgument) map[string]any {
+			var folderPath = getArgValue(args[0])
+			var pathParts = strings.Split(folderPath.(string), "/")
+			var fileLocationType = pathParts[0]
+
+			var filename = end(pathParts)
+			slices.Delete(pathParts, 0, len(pathParts)-1)
+			folderPath = strings.Trim(strings.Join(pathParts, "/"), "/")
+			var fileLocation = map[string]any{
+				"relativeSubpath": folderPath,
+			}
+
+			if fileLocationType == "~" {
+				fileLocation["WFFileLocationType"] = "Home"
+			}
+
+			return map[string]any{
+				"WFFile": map[string]any{
+					"fileLocation": fileLocation,
+					"filename":     filename,
+					"displayName":  filename,
+				},
+			}
 		},
 	},
 	"getFile": {


### PR DESCRIPTION
This changes getting a file at a path from a variable folder reference, and preferring instead to use something like "~/Downloads" or rather just give it the tilde folder path. Then the path to the file in your home folder.

```
getFileFromFolder("~/", "Downloads/myfolder/file.txt")
```