### PR TITLE
Refactor to require standard actions to be included

### DIFF
--- a/actions/device.cherri
+++ b/actions/device.cherri
@@ -2,10 +2,6 @@
 Device Actions
 */
 
-#define action setBrightness(float brightness: 'WFBrightness')
-
-#define action setVolume(float volume: 'WFVolume')
-
 #define action getOnScreenContent()
 
 #define action 'com.apple.ShortcutsActions.GetOrientationAction' getOrientation(): text
@@ -17,85 +13,6 @@ Device Actions
 #define action v17 reboot() {
 	"WFShutdownMode": "Restart"
 }
-
-#define action 'dnd.set' DNDOn() {
-	"Enabled": 1,
-	"FocusModes": {
-		"DisplayString": "Do Not Disturb",
-		"Identifier": "com.apple.donotdisturb.mode.default"
-	}
-}
-
-#define action 'dnd.set' DNDOff() {
-	"Enabled": 0,
-	"FocusModes": {
-		"DisplayString": "Do Not Disturb",
-		"Identifier": "com.apple.donotdisturb.mode.default"
-	}
-}
-
-#define action 'appearance' lightMode() {
-	"operation": "set",
-	"style": "light"
-}
-
-#define action default 'appearance' darkMode() {
-	"operation": "set",
-	"style": "dark"
-}
-
-enum backgroundSound {
-	'BalancedNoise',
-	'BrightNoise',
-	'DarkNoise',
-	'Ocean',
-	'Rain',
-	'Stream',
-}
-
-#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXSetBackgroundSoundIntent' setBackgroundSound(backgroundSound ?sound: 'backgroundSound' = "BalancedNoise")
-
-#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXSetBackgroundSoundVolumeIntent' setBackgroundSoundsVolume(float volume: 'volumeValue')
-
-enum textSizes {
-	'Accessibility Extra Extra Extra Large',
-	'Accessibility Extra Extra Large',
-	'Accessibility Extra Large',
-	'Accessibility Large',
-	'Accessibility Medium',
-	'Extra Extra Extra Large',
-	'Extra Extra Large',
-	'Extra Large',
-	'Default',
-	'Medium',
-	'Small',
-	'Extra Small',
-}
-
-#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXSetLargeTextIntent' setTextSize(textSizes size: 'textSize')
-
-enum soundRecognitionOperations {
-	'pause',
-	'activate',
-	'toggle',
-}
-
-#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXToggleSoundDetectionIntent' setSoundRecognition(soundRecognitionOperations ?operation = "activate")
-
-enum deviceDetail {
-	'Device Name',
-	'Device Hostname',
-	'Device Model',
-	'Device Is Watch',
-	'System Version',
-	'Screen Width',
-	'Screen Height',
-	'Current Volume',
-	'Current Brightness',
-	'Current Appearance',
-}
-
-#define action 'getdevicedetails' getDeviceDetail(deviceDetail detail: 'WFDeviceDetail')
 
 // [Doc]: Vibrate Device: Vibrate the device. Only applies to Apple devices with the haptic engine.
 #define action !mac vibrate()

--- a/actions/device.cherri
+++ b/actions/device.cherri
@@ -2,6 +2,21 @@
 Device Actions
 */
 
+enum deviceDetail {
+	'Device Name',
+	'Device Hostname',
+	'Device Model',
+	'Device Is Watch',
+	'System Version',
+	'Screen Width',
+	'Screen Height',
+	'Current Volume',
+	'Current Brightness',
+	'Current Appearance',
+}
+
+#define action 'getdevicedetails' getDeviceDetail(deviceDetail detail: 'WFDeviceDetail')
+
 #define action getOnScreenContent()
 
 #define action 'com.apple.ShortcutsActions.GetOrientationAction' getOrientation(): text
@@ -28,35 +43,3 @@ Device Actions
 #define action v16.2 'getbatterylevel' isCharging(): bool {
 	"Subject": "Is Charging"
 }
-
-/* Network */
-
-enum wifiDetail {
-	'Network Name',
-	'BSSID',
-	'Wi-Fi Standard',
-	'RX Rate',
-	'TX Rate',
-	'RSSI',
-	'Noise',
-	'Channel Number',
-	'Hardware MAC Address',
-}
-
-enum cellularDetail {
-	'Carrier Name',
-	'Radio Technology',
-	'Country Code',
-	'Is Roaming Abroad',
-	'Number of Signal Bars',
-}
-
-#define action 'getwifi' getWifiDetail(wifiDetail detail: 'WFWiFiDetail') {
-	"WFNetworkDetailsNetwork": "Wi-Fi"
-}
-
-#define action 'getwifi' getCellularDetail(cellularDetail detail: 'WFCellularDetail') {
-	"WFNetworkDetailsNetwork": "Cellular"
-}
-
-#define action 'connecttoservers' connectToServer(text url: 'WFInput')

--- a/actions/network.cherri
+++ b/actions/network.cherri
@@ -1,0 +1,33 @@
+/*
+Network Actions
+*/
+
+enum wifiDetail {
+	'Network Name',
+	'BSSID',
+	'Wi-Fi Standard',
+	'RX Rate',
+	'TX Rate',
+	'RSSI',
+	'Noise',
+	'Channel Number',
+	'Hardware MAC Address',
+}
+
+enum cellularDetail {
+	'Carrier Name',
+	'Radio Technology',
+	'Country Code',
+	'Is Roaming Abroad',
+	'Number of Signal Bars',
+}
+
+#define action 'getwifi' getWifiDetail(wifiDetail detail: 'WFWiFiDetail') {
+	"WFNetworkDetailsNetwork": "Wi-Fi"
+}
+
+#define action 'getwifi' getCellularDetail(cellularDetail detail: 'WFCellularDetail') {
+	"WFNetworkDetailsNetwork": "Cellular"
+}
+
+#define action 'connecttoservers' connectToServer(text url: 'WFInput')

--- a/actions/scripting.cherri
+++ b/actions/scripting.cherri
@@ -117,7 +117,6 @@ enum countType {
 
 #define action 'number.random' randomNumber(number min: 'WFRandomNumberMinimum', number max: 'WFRandomNumberMaximum'): number
 
-
 /* Passwords */
 
 #define action 'openpasswords' searchPasswords(text query: 'WFShowPasswordsSearchTerm')
@@ -125,11 +124,3 @@ enum countType {
 /* System */
 
 #define action dismissSiri()
-
-#define action 'wallpaper.set' setWallpaper(variable input: 'WFInput')
-
-#define action default !mac v16.2 'posters.get' getAllWallpapers(): array
-
-#define action !mac v16.2 'posters.get' getWallpaper() {
-	"WFPosterType": "Current"
-}

--- a/actions/settings.cherri
+++ b/actions/settings.cherri
@@ -1,0 +1,96 @@
+/*
+Device settings actions.
+*/
+
+/* Wallpaper */
+
+#define action 'wallpaper.set' setWallpaper(variable input: 'WFInput')
+
+#define action default !mac v16.2 'posters.get' getAllWallpapers(): array
+
+#define action !mac v16.2 'posters.get' getWallpaper() {
+	"WFPosterType": "Current"
+}
+
+#define action setBrightness(float brightness: 'WFBrightness')
+
+#define action setVolume(float volume: 'WFVolume')
+
+#define action 'dnd.set' DNDOn() {
+	"Enabled": 1,
+	"FocusModes": {
+		"DisplayString": "Do Not Disturb",
+		"Identifier": "com.apple.donotdisturb.mode.default"
+	}
+}
+
+#define action 'dnd.set' DNDOff() {
+	"Enabled": 0,
+	"FocusModes": {
+		"DisplayString": "Do Not Disturb",
+		"Identifier": "com.apple.donotdisturb.mode.default"
+	}
+}
+
+#define action 'appearance' lightMode() {
+	"operation": "set",
+	"style": "light"
+}
+
+#define action default 'appearance' darkMode() {
+	"operation": "set",
+	"style": "dark"
+}
+
+enum backgroundSound {
+	'BalancedNoise',
+	'BrightNoise',
+	'DarkNoise',
+	'Ocean',
+	'Rain',
+	'Stream',
+}
+
+#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXSetBackgroundSoundIntent' setBackgroundSound(backgroundSound ?sound: 'backgroundSound' = "BalancedNoise")
+
+#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXSetBackgroundSoundVolumeIntent' setBackgroundSoundsVolume(float volume: 'volumeValue')
+
+enum textSizes {
+	'Accessibility Extra Extra Extra Large',
+	'Accessibility Extra Extra Large',
+	'Accessibility Extra Large',
+	'Accessibility Large',
+	'Accessibility Medium',
+	'Extra Extra Extra Large',
+	'Extra Extra Large',
+	'Extra Large',
+	'Default',
+	'Medium',
+	'Small',
+	'Extra Small',
+}
+
+#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXSetLargeTextIntent' setTextSize(textSizes size: 'textSize')
+
+enum soundRecognitionOperations {
+	'pause',
+	'activate',
+	'toggle',
+}
+
+#define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXToggleSoundDetectionIntent' setSoundRecognition(soundRecognitionOperations ?operation = "activate")
+
+enum deviceDetail {
+	'Device Name',
+	'Device Hostname',
+	'Device Model',
+	'Device Is Watch',
+	'System Version',
+	'Screen Width',
+	'Screen Height',
+	'Current Volume',
+	'Current Brightness',
+	'Current Appearance',
+}
+
+#define action 'getdevicedetails' getDeviceDetail(deviceDetail detail: 'WFDeviceDetail')

--- a/actions/settings.cherri
+++ b/actions/settings.cherri
@@ -2,16 +2,6 @@
 Device settings actions.
 */
 
-/* Wallpaper */
-
-#define action 'wallpaper.set' setWallpaper(variable input: 'WFInput')
-
-#define action default !mac v16.2 'posters.get' getAllWallpapers(): array
-
-#define action !mac v16.2 'posters.get' getWallpaper() {
-	"WFPosterType": "Current"
-}
-
 #define action setBrightness(float brightness: 'WFBrightness')
 
 #define action setVolume(float volume: 'WFVolume')
@@ -41,6 +31,8 @@ Device settings actions.
 	"operation": "set",
 	"style": "dark"
 }
+
+/* Accessibility */
 
 enum backgroundSound {
 	'BalancedNoise',
@@ -80,17 +72,12 @@ enum soundRecognitionOperations {
 
 #define action 'com.apple.AccessibilityUtilities.AXSettingsShortcuts.AXToggleSoundDetectionIntent' setSoundRecognition(soundRecognitionOperations ?operation = "activate")
 
-enum deviceDetail {
-	'Device Name',
-	'Device Hostname',
-	'Device Model',
-	'Device Is Watch',
-	'System Version',
-	'Screen Width',
-	'Screen Height',
-	'Current Volume',
-	'Current Brightness',
-	'Current Appearance',
-}
+/* Wallpaper */
 
-#define action 'getdevicedetails' getDeviceDetail(deviceDetail detail: 'WFDeviceDetail')
+#define action 'wallpaper.set' setWallpaper(variable input: 'WFInput')
+
+#define action default !mac v16.2 'posters.get' getAllWallpapers(): array
+
+#define action !mac v16.2 'posters.get' getWallpaper() {
+	"WFPosterType": "Current"
+}

--- a/actions_std.go
+++ b/actions_std.go
@@ -2035,7 +2035,7 @@ func checkMissingStandardInclude(identifier *string, parsing bool) {
 
 		var includeStatement = fmt.Sprintf("#include 'actions/%s'", actionInclude)
 		if parsing {
-			parserError(fmt.Sprintf("Action '%s()' requires include:\n\n%s", name, includeStatement))
+			exit(fmt.Sprintf("Action '%s()' requires include:\n\n%s", name, includeStatement))
 		} else {
 			popLine(includeStatement)
 			break

--- a/actions_std.go
+++ b/actions_std.go
@@ -1940,7 +1940,7 @@ func defineRawAction() {
 	}
 }
 
-func handleRawParams(params map[string]interface{}) {
+func handleRawParams(params map[string]any) {
 	for key, value := range params {
 		if reflect.TypeOf(value).Kind() != reflect.String || !strings.ContainsAny(value.(string), "{}") {
 			continue

--- a/cherri_test.go
+++ b/cherri_test.go
@@ -26,7 +26,7 @@ func TestCherri(_ *testing.T) {
 	}
 	loadStandardActions()
 	for _, file := range files {
-		if !strings.Contains(file.Name(), ".cherri") || file.Name() == "decomp_expected.cherri" {
+		if !strings.Contains(file.Name(), ".cherri") || file.Name() == "decomp_expected.cherri" || file.Name() == "decomp_me.cherri" {
 			continue
 		}
 		currentTest = fmt.Sprintf("tests/%s", file.Name())

--- a/cherri_test.go
+++ b/cherri_test.go
@@ -24,8 +24,9 @@ func TestCherri(_ *testing.T) {
 		fmt.Println(ansi("FAILED: unable to read tests directory", red))
 		panic(err)
 	}
+	loadStandardActions()
 	for _, file := range files {
-		if !strings.Contains(file.Name(), ".cherri") {
+		if !strings.Contains(file.Name(), ".cherri") || file.Name() == "decomp_expected.cherri" {
 			continue
 		}
 		currentTest = fmt.Sprintf("tests/%s", file.Name())

--- a/decompile.go
+++ b/decompile.go
@@ -7,6 +7,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"regexp"

--- a/parser.go
+++ b/parser.go
@@ -114,7 +114,7 @@ func preParse() {
 	)
 	defineRawAction()
 
-	includeStandardActions()
+	includeBasicStandardActions()
 	handleIncludes()
 
 	handleCopyPastes()
@@ -1473,6 +1473,7 @@ func collectActionCall() {
 
 func collectAction(identifier *string) (value action) {
 	if _, found := actions[*identifier]; !found {
+		checkMissingStandardInclude(identifier, true)
 		parserError(fmt.Sprintf("Undefined action '%s()'", *identifier))
 	}
 	advance()

--- a/tests/decomp_expected.cherri
+++ b/tests/decomp_expected.cherri
@@ -1,3 +1,4 @@
+#include 'actions/scripting'
 #define color red
 #define glyph apple
 

--- a/tests/decomp_me.cherri
+++ b/tests/decomp_me.cherri
@@ -1,3 +1,4 @@
+#include 'actions/scripting'
 #define color red
 #define glyph apple
 

--- a/tests/include-actions.cherri
+++ b/tests/include-actions.cherri
@@ -1,4 +1,2 @@
-#include 'actions/dropbox'
-
 @file = selectFile()
 saveToDropboxPrompt(file)


### PR DESCRIPTION
This would refactor the compiler to no longer include all of the standard action definitions when compiling and decompiling, so as to not waste memory.

To facilitate the transition, logic is added to inform the user of which include they need to use:

<img width="348" alt="Screenshot 2025-06-14 at 17 37 20" src="https://github.com/user-attachments/assets/fcf1ec75-fa2c-44e7-85d9-ba22992f1603" />

Decompilation will add include statements to the top of the generated Cherri code as needed.