### PR TITLE
Fix parsing error when there is a comment before #include

### DIFF
--- a/action.go
+++ b/action.go
@@ -714,6 +714,7 @@ func parseActionDefinitions() {
 			collectComment()
 			preParsing = true
 			delete(args.Args, "comments")
+			continue
 		case tokenAhead(Enumeration):
 			collectEnumeration()
 		case tokenAhead(Definition):

--- a/includes.go
+++ b/includes.go
@@ -53,6 +53,7 @@ func parseIncludes() {
 		switch {
 		case isChar('/'):
 			collectComment()
+			continue
 		case tokenAhead(Include):
 			advance()
 			parseInclude()


### PR DESCRIPTION
This PR fixes a parsing error that occurs when there is a comment before an `#include` or a `#define action` statement.

**Problem:**
When a comment `*/` appears before an `#include` directive, the parser would fail to properly handle the include statement, causing parsing errors.
