### PR TITLE
bugfix #107: Fix and improve expression parsing

### DIFF
--- a/action.go
+++ b/action.go
@@ -831,7 +831,7 @@ func collectVersionDefinition() (minVersion float64, maxVersion float64) {
 		advance()
 		var valueType tokenType
 		var version any
-		collectIntegerValue(&valueType, &version, ' ')
+		collectIntegerValue(&valueType, &version)
 
 		switch char {
 		case '>':

--- a/parser.go
+++ b/parser.go
@@ -296,6 +296,9 @@ func collectVariableValue(constant bool, valueType *tokenType, value *any) {
 
 	var aheadOfValue = lookAheadUntil('\n')
 	if containsExpressionTokens(aheadOfValue) {
+		if !slices.Contains([]tokenType{Integer, Float, Variable}, *valueType) {
+			parserError(fmt.Sprintf("Value of type '%s' not allowed in expression", *valueType))
+		}
 		if *valueType == Variable {
 			var valueRef = *value
 			*value = fmt.Sprintf("%s %s", valueRef.(varValue).value, aheadOfValue)

--- a/parser.go
+++ b/parser.go
@@ -296,8 +296,13 @@ func collectVariableValue(constant bool, valueType *tokenType, value *any) {
 
 	var aheadOfValue = lookAheadUntil('\n')
 	if containsExpressionTokens(aheadOfValue) {
+		if *valueType == Variable {
+			var valueRef = *value
+			*value = fmt.Sprintf("%s %s", valueRef.(varValue).value, aheadOfValue)
+		} else {
+			*value = fmt.Sprintf("%v %s", *value, aheadOfValue)
+		}
 		*valueType = Expression
-		*value = fmt.Sprintf("%v %s", *value, aheadOfValue)
 		advanceUntil('\n')
 	}
 	if constant && (*valueType == Arr || *valueType == Variable) {

--- a/parser.go
+++ b/parser.go
@@ -338,7 +338,7 @@ func collectExpression(valueType *tokenType, value *any) {
 			var intValueType tokenType
 			var intValue any
 			collectIntegerValue(&intValueType, &intValue)
-			*value = fmt.Sprintf("%s %d", *value, intValue)
+			*value = fmt.Sprintf("%s %v", *value, intValue)
 		default:
 			var until = ' '
 			var refType tokenType

--- a/parser.go
+++ b/parser.go
@@ -342,9 +342,6 @@ func collectValue(valueType *tokenType, value *any, until rune) {
 		advanceUntil(until)
 	case strings.Contains(ahead, "("):
 		collectActionValue(valueType, value)
-	case containsTokens(&ahead, Plus, Minus, Multiply, Divide, Modulus):
-		*valueType = Expression
-		*value = collectUntil(until)
 	default:
 		collectReference(valueType, value, &until)
 	}

--- a/parser.go
+++ b/parser.go
@@ -313,7 +313,7 @@ func collectValue(valueType *tokenType, value *any, until rune) {
 		if strings.Contains(ahead, ".") {
 			*valueType = Float
 		}
-		collectIntegerValue(valueType, value, until)
+		collectIntegerValue(valueType, value)
 	case char == '"':
 		collectStringValue(valueType, value)
 	case char == '\'':
@@ -1295,26 +1295,19 @@ func collectInteger() string {
 	return collection.String()
 }
 
-func collectIntegerValue(valueType *tokenType, value *any, until rune) {
-	var ahead = lookAheadUntil(until)
-	if !containsTokens(&ahead, Plus, Minus, Multiply, Divide, Modulus) {
-		var integerString = collectInteger()
+func collectIntegerValue(valueType *tokenType, value *any) {
+	var integerString = collectInteger()
+	if *valueType == Integer {
+		var integer, convErr = strconv.Atoi(integerString)
+		handle(convErr)
 
-		if *valueType == Integer {
-			var integer, convErr = strconv.Atoi(integerString)
-			handle(convErr)
+		*value = integer
+	} else {
+		var float, floatErr = strconv.ParseFloat(integerString, 64)
+		handle(floatErr)
 
-			*value = integer
-		} else {
-			var float, floatErr = strconv.ParseFloat(integerString, 64)
-			handle(floatErr)
-
-			*value = float
-		}
-		return
+		*value = float
 	}
-	*valueType = Expression
-	*value = collectUntil(until)
 }
 
 func collectString() string {

--- a/parser.go
+++ b/parser.go
@@ -294,6 +294,12 @@ func lookAheadUntil(until rune) string {
 func collectVariableValue(constant bool, valueType *tokenType, value *any) {
 	collectValue(valueType, value, '\n')
 
+	var aheadOfValue = lookAheadUntil('\n')
+	if containsExpressionTokens(aheadOfValue) {
+		*valueType = Expression
+		*value = fmt.Sprintf("%v %s", *value, aheadOfValue)
+		advanceUntil('\n')
+	}
 	if constant && (*valueType == Arr || *valueType == Variable) {
 		parserError(fmt.Sprintf("Type %v values cannot be constants.", *valueType))
 	}
@@ -1543,6 +1549,10 @@ func tokenAhead(token tokenType) bool {
 
 	advanceTimes(tokenLen)
 	return true
+}
+
+func containsExpressionTokens(str string) bool {
+	return containsTokens(&str, Plus, Minus, Multiply, Divide, Modulus, LeftParen, RightParen)
 }
 
 func containsTokens(str *string, v ...tokenType) bool {

--- a/parser.go
+++ b/parser.go
@@ -293,9 +293,6 @@ func lookAheadUntil(until rune) string {
 
 func collectVariableValue(constant bool, valueType *tokenType, value *any) {
 	collectValue(valueType, value, '\n')
-	if constant && (*valueType == Arr || *valueType == Variable) {
-		parserError(fmt.Sprintf("Type %v values cannot be constants.", *valueType))
-	}
 	if *valueType == Question {
 		parserError(fmt.Sprintf("Illegal reference to import question '%s'. Shortcuts does not support import questions as variable values.", *value))
 	}
@@ -307,6 +304,9 @@ func collectVariableValue(constant bool, valueType *tokenType, value *any) {
 	if containsExpressionTokens(aheadOfValue) {
 		collectExpression(valueType, value)
 		return
+	}
+	if constant && (*valueType == Arr || *valueType == Variable) {
+		parserError(fmt.Sprintf("Type %v values cannot be constants.", *valueType))
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -328,6 +328,9 @@ func collectValue(valueType *tokenType, value *any, until rune) {
 		advance()
 		*valueType = Dict
 		*value = collectDictionary()
+	case char == '(':
+		*valueType = Expression
+		*value = collectUntil(until)
 	case tokenAhead(True):
 		*valueType = Bool
 		*value = true

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -260,11 +260,8 @@ func makeExpressionValue(reference *map[string]any, value *any) {
 		return
 	}
 
-	var formattedExpression = wrapExpressionReferences(&expression)
-	fmt.Println("formattedExpression:", formattedExpression)
-
 	addStdAction("calculateexpression", attachReferenceToParams(&map[string]any{
-		"Input": attachmentValues(formattedExpression),
+		"Input": attachmentValues(expression),
 	}, reference))
 }
 
@@ -284,9 +281,6 @@ func makeMathValue(reference *map[string]any, expression string, expressionParts
 
 	operandOne = strings.Trim(expressionParts[0], " ")
 	operandTwo = strings.Trim(expressionParts[1], " ")
-
-	wrapVariableReference(&operandOne)
-	wrapVariableReference(&operandTwo)
 
 	switch operation {
 	case "*":

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -252,10 +252,7 @@ func makeBoolValue(reference *map[string]any, value *any) {
 	}, reference))
 }
 
-var formattedExpression []string
-
 func makeExpressionValue(reference *map[string]any, value *any) {
-	formattedExpression = []string{}
 	var expression = fmt.Sprintf("%s", *value)
 	var expressionParts = strings.Split(expression, " ")
 	if len(expressionParts) == 3 && containsTokens(&expression, Plus, Minus, Multiply, Divide) {
@@ -263,18 +260,19 @@ func makeExpressionValue(reference *map[string]any, value *any) {
 		return
 	}
 
-	expressionParts = strings.Split(expression, " ")
-	for _, part := range expressionParts {
-		var p = part
-		wrapVariableReference(&p)
-		formattedExpression = append(formattedExpression, p)
-	}
-
-	expression = strings.Join(formattedExpression, " ")
+	var formattedExpression = wrapExpressionReferences(&expression)
+	fmt.Println("formattedExpression:", formattedExpression)
 
 	addStdAction("calculateexpression", attachReferenceToParams(&map[string]any{
-		"Input": attachmentValues(expression),
+		"Input": attachmentValues(formattedExpression),
 	}, reference))
+}
+
+var identifierRegex = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9_]*)`)
+
+func wrapExpressionReferences(expression *string) string {
+	fmt.Println(identifierRegex.FindAllStringSubmatch(*expression, -1))
+	return identifierRegex.ReplaceAllString(*expression, "{$1}")
 }
 
 func makeMathValue(reference *map[string]any, expression string, expressionParts []string) {

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -265,13 +265,6 @@ func makeExpressionValue(reference *map[string]any, value *any) {
 	}, reference))
 }
 
-var identifierRegex = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9_]*)`)
-
-func wrapExpressionReferences(expression *string) string {
-	fmt.Println(identifierRegex.FindAllStringSubmatch(*expression, -1))
-	return identifierRegex.ReplaceAllString(*expression, "{$1}")
-}
-
 func makeMathValue(reference *map[string]any, expression string, expressionParts []string) {
 	var operandOne string
 	var operandTwo string

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -259,23 +259,7 @@ func makeExpressionValue(reference *map[string]any, value *any) {
 	var expression = fmt.Sprintf("%s", *value)
 	var expressionParts = strings.Split(expression, " ")
 	if len(expressionParts) == 3 && containsTokens(&expression, Plus, Minus, Multiply, Divide) {
-		var operandOne string
-		var operandTwo string
-
-		var operation = expressionParts[1]
-		expressionParts = strings.Split(expression, operation)
-		operandOne = strings.Trim(expressionParts[0], " ")
-		operandTwo = strings.Trim(expressionParts[1], " ")
-		wrapVariableReference(&operandOne)
-		wrapVariableReference(&operandTwo)
-
-		addStdAction("math", attachReferenceToParams(&map[string]any{
-			"WFScientificMathOperation": attachmentValues(operation),
-			"WFMathOperation":           attachmentValues(operation),
-			"WFInput":                   attachmentValues(operandOne),
-			"WFMathOperand":             attachmentValues(operandTwo),
-		}, reference))
-
+		makeMathValue(reference, expression, expressionParts)
 		return
 	}
 
@@ -291,6 +275,35 @@ func makeExpressionValue(reference *map[string]any, value *any) {
 	addStdAction("calculateexpression", attachReferenceToParams(&map[string]any{
 		"Input": attachmentValues(expression),
 	}, reference))
+}
+
+func makeMathValue(reference *map[string]any, expression string, expressionParts []string) {
+	var operandOne string
+	var operandTwo string
+
+	var operation = expressionParts[1]
+	expressionParts = strings.Split(expression, operation)
+
+	operandOne = strings.Trim(expressionParts[0], " ")
+	operandTwo = strings.Trim(expressionParts[1], " ")
+
+	wrapVariableReference(&operandOne)
+	wrapVariableReference(&operandTwo)
+
+	switch operation {
+	case "*":
+		operation = "×"
+	case "/":
+		operation = "÷"
+	}
+
+	addStdAction("math", attachReferenceToParams(&map[string]any{
+		"WFMathOperation": operation,
+		"WFInput":         attachmentValues(operandOne),
+		"WFMathOperand":   attachmentValues(operandTwo),
+	}, reference))
+
+	return
 }
 
 func makeDictionaryValue(value *any) map[string]any {

--- a/token.go
+++ b/token.go
@@ -103,6 +103,8 @@ const (
 	Multiply       tokenType = "*"
 	Divide         tokenType = "/"
 	Modulus        tokenType = "%"
+	LeftParen      tokenType = "("
+	RightParen     tokenType = ")"
 	LeftBrace      tokenType = "{"
 	RightBrace     tokenType = "}"
 	Colon          tokenType = ":"


### PR DESCRIPTION
Fixes and improves parsing variable expression values. This is mainly to fix expressions being confused with other code that uses characters like `/`, comments primarily.

In doing this, other issues were identified with expressions:
- Multiplication or division of two operands, the operator would not be replaced with the special characters the Shortcuts app uses.
- Expressions with parentheses couldn't use variable references.

The following improvements have also been made:
- We now ensure all references, characters, and values in an expression are valid during parsing rather than during Shortcut generation. This allows for a much more precise error message if a reference in an expression is undefined.
- This allows us to wrap references in brackets when we parse them, rather than needing to add them later.

