### PR TITLE
Fix variable interpolation with UTF-16 multi-byte characters

### DIFF
--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -566,28 +566,29 @@ func makeAggrandizement(valueType *tokenType, variable *varValue, getAs string) 
 	return aggrandizement
 }
 
+const utf16BMPThreshold = 0x10000
+
 // mapInlineVars finds occurrences of ObjectReplaceChar and adds them to inlineVars to map the inline variables in noVarString.
-// Uses UTF-16 code unit positions to match Apple Shortcuts' encoding requirements.
+// Accounts for UTF-16 characters with code units which require the inline variable position to be doubled (e.g. emoji, bold text).
 func mapInlineVars(noVarString *string) {
 	var variableIdx int
-	var utf16Pos = 0
+	var charPos = 0
 
 	for _, r := range *noVarString {
 		if r == ObjectReplaceChar {
 			inlineVars = append(inlineVars, inlineVar{
 				identifier: varIndex[variableIdx].identifier,
-				col:        utf16Pos,
+				col:        charPos,
 				getAs:      varIndex[variableIdx].getAs,
 				coerce:     varIndex[variableIdx].coerce,
 			})
 			variableIdx++
 		}
 
-		// Count UTF-16 code units: surrogate pairs (outside BMP) count as 2
-		if r >= 0x10000 {
-			utf16Pos += 2
+		if r >= utf16BMPThreshold {
+			charPos += 2
 		} else {
-			utf16Pos += 1
+			charPos += 1
 		}
 	}
 }

--- a/tests/variable_interpolation_utf16.cherri
+++ b/tests/variable_interpolation_utf16.cherri
@@ -1,7 +1,5 @@
 /* Test variable interpolation with UTF-16 multi-byte characters */
 
-#include 'actions/intelligence'
-
 // Test 1: Variable after emoji
 @testVar1 = "value1"
 @result1 = "✅ Emoji before: {testVar1}"


### PR DESCRIPTION
## Summary
Fixes variable interpolation bug when strings contain emojis or characters outside the Basic Multilingual Plane (BMP).

## Problem
Variables in strings were not interpolating correctly when emojis or other multi-byte UTF-16 characters appeared before the variable position. This was due to `mapInlineVars()` counting Go runes instead of UTF-16 code units.

Apple Shortcuts uses UTF-16 encoding for `attachmentsByRange` positions, where characters outside BMP (U+10000+) require surrogate pairs (2 UTF-16 code units).

## Example Bug

```javascript
const test = prompt("Enter:")

// Emojis before variable
const withEmoji = "✅ 📝 Test: {test}"

// Should work without duplication
show("{withEmoji}")
```

## Screenshots

### Before

<img width="1472" height="620" alt="image" src="https://github.com/user-attachments/assets/54f589d6-7710-4788-9a39-36251443350b" />

### After

<img width="1646" height="586" alt="image" src="https://github.com/user-attachments/assets/69f97885-e067-4f7f-abb0-b2dbb2e6615d" />


## Changes
- Modified: `shortcutgen.go:569-585` - Fixed `mapInlineVars()` function
- Added: `tests/variable_interpolation_utf16.cherri` - Comprehensive test cases

## Related issue

Fixes #120 