### PR TITLE
Improve macOS native signing and add CI test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,6 +54,9 @@ jobs:
     - name: Package Manager Test
       run: go test -run TestPackages -v ./...
 
+    - name: MacOS Native Signing Test
+      run: go test -run TestMacOSSigning -v ./...
+
   build-test-nix:
     runs-on: ubuntu-latest
     steps:

--- a/cherri_test.go
+++ b/cherri_test.go
@@ -18,6 +18,9 @@ var currentTest string
 
 func TestCherri(_ *testing.T) {
 	args.Args["no-ansi"] = ""
+	// Use "anyone" signing mode which is more reliable on macOS 14.4+/15.x
+	// The "people-who-know-me" mode has iCloud/network dependencies that can fail
+	args.Args["share"] = "anyone"
 	var files, err = os.ReadDir("tests")
 	if err != nil {
 		fmt.Println(ansi("FAILED: unable to read tests directory", red))

--- a/signing_darwin_test.go
+++ b/signing_darwin_test.go
@@ -1,0 +1,74 @@
+//go:build darwin
+
+/*
+ * Copyright (c) Cherri
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/electrikmilk/args-parser"
+)
+
+// TestMacOSSigning verifies that native macOS signing works correctly.
+// This test only runs on macOS (darwin) and will fail if the `shortcuts sign` command
+// fails, indicating that the code is falling back to an external signing service.
+func TestMacOSSigning(t *testing.T) {
+	args.Args["no-ansi"] = ""
+	// Use "anyone" signing mode which is confirmed to work on macOS 14.4+/15.x
+	// The "people-who-know-me" mode may have iCloud/network dependencies that fail
+	args.Args["share"] = "anyone"
+
+	// Reset signFailed before testing
+	signFailed = false
+
+	var files, err = os.ReadDir("tests")
+	if err != nil {
+		t.Fatalf("Failed to read tests directory: %v", err)
+	}
+
+	loadStandardActions()
+
+	// Find the first valid test file to compile
+	var testFile string
+	for _, file := range files {
+		if file.Name() == "decomp_expected.cherri" || file.Name() == "decomp_me.cherri" {
+			continue
+		}
+		if len(file.Name()) > 7 && file.Name()[len(file.Name())-7:] == ".cherri" {
+			testFile = fmt.Sprintf("tests/%s", file.Name())
+			break
+		}
+	}
+
+	if testFile == "" {
+		t.Skip("No test files found")
+	}
+
+	currentTest = testFile
+	os.Args[1] = testFile
+	fmt.Println("Testing macOS native signing with:", testFile)
+
+	// Compile the shortcut (which includes signing)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Compilation panicked: %v", r)
+		}
+	}()
+
+	compile()
+
+	// Check if native macOS signing failed
+	if signFailed {
+		t.Error("macOS native signing failed - code fell back to external signing service. " +
+			"The `shortcuts sign` command is not working correctly on this system.")
+	} else {
+		fmt.Println("✅ macOS native signing succeeded")
+	}
+
+	resetParser()
+}


### PR DESCRIPTION
This PR improves macOS native signing by checking for output file existence and AEA1 magic bytes, avoiding false negatives from macOS CLI noise. It also adds a new macOS-specific test and updates the GitHub Actions workflow to run it.

It addresses #49  in a way that works on my my mac sequoia 15.6

I lack a lot of context and don't fully understand the consequences of those changes, so please review carefully and treat those changes more as a suggestion / inspiration.