### PR TITLE
Fix panic on #-prefixed quantity types (timerDuration, dateUnit, storageUnit)

### DIFF
--- a/action.go
+++ b/action.go
@@ -958,6 +958,10 @@ func collectEnumerationType(valueType *tokenType, quantity *bool, until rune) (e
 	if enumerations[ahead] != nil {
 		enumeration = collectUntil(until)
 		*valueType = String
+	} else if *quantity {
+		// Consume the unit type qualifier (e.g. timerDuration, dateUnit, storageUnit)
+		// even though it's not an enumeration, so the parser advances past it.
+		collectUntil(until)
 	}
 
 	if *quantity {
@@ -974,7 +978,7 @@ func collectParameterDefinitions() (arguments []parameterDefinition) {
 
 		var quantity bool
 		var enumeration = collectEnumerationType(&valueType, &quantity, ' ')
-		if enumeration == "" {
+		if enumeration == "" && !quantity {
 			collectType(&valueType, &value, ' ')
 		}
 


### PR DESCRIPTION
## Summary

Fixes #148 — `#include 'actions/music'` (and calendar, mac) crash the compiler because `#timerDuration`, `#dateUnit`, and `#storageUnit` are not recognized by the parser.

## Root Cause

`collectEnumerationType` consumes the `#` prefix and sets `quantity = true`, but when the following text isn't a registered enumeration, it doesn't consume it. Control falls through to `collectType` which panics on the unknown type name.

## Fix

Two changes in `action.go`:

1. **`collectEnumerationType`**: consume the unit type qualifier text even when it's not an enumeration
2. **`collectParameterDefinitions`**: skip `collectType` when quantity type is already determined

## Test

```cherri
#define name Test
#include 'actions/music'
addToMusic(ShortcutInput)
```

Before: `Unknown type 'timerDuration'` panic
After: compiles successfully