### PR TITLE
Fix multiple rawAction() calls sharing the last call's identifier

### DIFF
--- a/action.go
+++ b/action.go
@@ -64,6 +64,8 @@ type action struct {
 	def *actionDefinition
 	// args are each of the arguments collected between the actions' parenthesis.
 	args []actionArgument
+	// overrideIdentifier holds a per-invocation identifier override (e.g. from rawAction).
+	overrideIdentifier string
 }
 
 // checkFunc is a function that can be passed a collected actions arguments as a slice of actionArgument and the current action's definition.
@@ -1046,9 +1048,10 @@ func collectParameterDefinitions() (arguments []parameterDefinition) {
 
 func makeActionValue(identifier string, arguments []actionArgument) action {
 	return action{
-		ident: identifier,
-		def:   actions[identifier],
-		args:  arguments,
+		ident:              identifier,
+		def:                actions[identifier],
+		args:               arguments,
+		overrideIdentifier: currentAction.overrideIdentifier,
 	}
 }
 

--- a/actions_std.go
+++ b/actions_std.go
@@ -1863,8 +1863,8 @@ func defineRawAction() {
 				validType: Dict,
 			},
 		},
-		check: func(args []actionArgument, _ *actionDefinition) {
-			actions["rawAction"].overrideIdentifier = getArgValue(args[0]).(string)
+		check: func(args []actionArgument, def *actionDefinition) {
+			def.overrideIdentifier = getArgValue(args[0]).(string)
 		},
 		make: func(args []actionArgument) map[string]any {
 			if len(args) == 1 {

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -91,6 +91,7 @@ func generateActions() {
 				exit(fmt.Sprintf("Undefined action '%s'", tokenAction.ident))
 			}
 			setCurrentAction(tokenAction.ident, actions[tokenAction.ident])
+			currentAction.overrideIdentifier = tokenAction.overrideIdentifier
 			makeAction(tokenAction.args, &map[string]any{})
 		case Repeat:
 			makeRepeatAction(&t)
@@ -197,6 +198,7 @@ func makeVariableValue(reference *map[string]any, valueType tokenType, value *an
 		var valuePtr = *value
 		var action = valuePtr.(action)
 		setCurrentAction(action.ident, actions[action.ident])
+		currentAction.overrideIdentifier = action.overrideIdentifier
 		makeAction(action.args, reference)
 	case Dict:
 		addStdAction("dictionary", attachReferenceToParams(&map[string]any{


### PR DESCRIPTION
## Summary

Fixes #149 — when a file has 2+ `rawAction()` calls, all compile with the last call's identifier.

## Root Cause

`rawAction`'s `check` callback writes to `actions["rawAction"].overrideIdentifier` (the shared definition) instead of the per-invocation `currentAction`. Since all invocations overwrite the same field, only the last value survives to generation.

## Fix

Three changes across `action.go`, `actions_std.go`, `shortcutgen.go`:

1. Use the `def` parameter in rawAction's `check` (writes to per-invocation `currentAction`)
2. Add `overrideIdentifier` field to the `action` struct to carry per-invocation state
3. Apply per-action override during shortcut generation (2 code paths)

## Test

```cherri
#define name Test
rawAction("is.workflow.actions.filter.itunes", {"WFSearchTerm": "test"})
rawAction("is.workflow.actions.addtoplaylist", {"placeholder": "unused"})
```

Before: both actions get `addtoplaylist`
After: first gets `filter.itunes`, second gets `addtoplaylist`