### PR TITLE
fix: avoid panic on empty identifier capitalization

### DIFF
--- a/decompile_identifier_test.go
+++ b/decompile_identifier_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestCapitalizeEmptyString(t *testing.T) {
+	if got := capitalize(""); got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestSanitizeIdentifierWhitespaceOnly(t *testing.T) {
+	specialCharsRegex = regexp.MustCompile("[^a-zA-Z0-9_]+")
+	identifier := " "
+
+	sanitizeIdentifier(&identifier)
+
+	if identifier != "" {
+		t.Fatalf("expected sanitized identifier to be empty, got %q", identifier)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -257,6 +257,9 @@ func end(slice []string) string {
 }
 
 func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
 	var char = s[0]
 	var after, _ = strings.CutPrefix(s, string(char))
 	return fmt.Sprintf("%c%s", unicode.ToUpper(rune(char)), after)


### PR DESCRIPTION
Fixes #145

When imported shortcut output names contain only whitespace, sanitizeIdentifier can pass empty strings to capitalize(), which then panics on s[0].

This adds a guard in capitalize() for empty input and includes regression tests for both capitalize("") and whitespace-only identifier sanitization.

Greetings, saschabuehrle