### PR TITLE
Fix action definition identifier threshold for third-party apps

### DIFF
--- a/action.go
+++ b/action.go
@@ -827,7 +827,8 @@ func collectDefinedAction() {
 		advance()
 
 		var workflowIdentifier = collectRawString()
-		if len(strings.Split(workflowIdentifier, ".")) < 4 {
+		var parts = strings.Split(workflowIdentifier, ".")
+		if len(parts) < 3 || (len(parts) == 3 && workflowIdentifier == strings.ToLower(workflowIdentifier)) {
 			shortIdentifier = workflowIdentifier
 		} else {
 			overrideIdentifier = workflowIdentifier

--- a/cherri_test.go
+++ b/cherri_test.go
@@ -123,6 +123,42 @@ func TestDecomp(t *testing.T) {
 	fmt.Print(ansi("✅  PASSED", green, bold) + "\n\n")
 }
 
+func TestActionIdentifiers(t *testing.T) {
+	args.Args["no-ansi"] = ""
+	args.Args["skip-sign"] = ""
+	loadStandardActions()
+
+	currentTest = "tests/zz-action-identifiers.cherri"
+	os.Args[1] = currentTest
+
+	compile()
+
+	var expected = []string{
+		"is.workflow.actions.shortid",
+		"is.workflow.actions.two.parts",
+		"is.workflow.actions.text.match.getgroup",
+		"notion.id.CreatePageIntent",
+		"com.apple.facetime.facetime",
+	}
+
+	var actual []string
+	for _, a := range shortcut.WFWorkflowActions {
+		actual = append(actual, a.WFWorkflowActionIdentifier)
+	}
+
+	if len(actual) != len(expected) {
+		t.Fatalf("Expected %d actions, got %d: %v", len(expected), len(actual), actual)
+	}
+
+	for i, ident := range expected {
+		if actual[i] != ident {
+			t.Errorf("Action %d: got %q, want %q", i, actual[i], ident)
+		}
+	}
+
+	resetParser()
+}
+
 func compile() {
 	defer func() {
 		if recover() != nil {

--- a/tests/zz-action-identifiers.cherri
+++ b/tests/zz-action-identifiers.cherri
@@ -1,0 +1,24 @@
+enum identifierType {
+    'Short',
+    'Override'
+}
+
+action 'shortid' shortAction(text input: 'WFInput')
+
+action 'two.parts' twoPartAction(text input: 'WFInput')
+
+action 'text.match.getgroup' threePartLower(text input: 'WFInput')
+
+action 'notion.id.CreatePageIntent' threePartUpper(text input: 'WFInput')
+
+action 'com.apple.facetime.facetime' fourPartAction(text input: 'WFInput')
+
+shortAction("a")
+
+twoPartAction("b")
+
+threePartLower("c")
+
+threePartUpper("d")
+
+fourPartAction("e")


### PR DESCRIPTION
Third-party app intent identifiers like `notion.id.CreatePageIntent` have 3 dot-separated parts. The current threshold of `< 4` in `collectDefinedAction()` treats them as short identifiers and prefixes them with `is.workflow.actions.`, which breaks them.

A simple `< 3` change would break standard 3-part suffixes like `text.match.getgroup` that need the prefix. Instead, this uses a smarter check: 3-part identifiers that are all lowercase are kept as short identifiers (standard actions), while 3-part identifiers with uppercase are treated as overrides (third-party AppIntents). 4+ part identifiers are always overrides, same as before.