### PR TITLE
Fix timerDuration type not found in actions/music

### DIFF
--- a/actions/basic.cherri
+++ b/actions/basic.cherri
@@ -108,3 +108,9 @@ action waitToReturn()
 
 // [Doc]: [Search] Search/Spotlight: Get results from search on iOS or iPadOS, and Spotlight on macOS.
 action 'spotlightsearch' search(text query: 'WFInputText', number ?limit: 'WFSpotlightSearchLimit' = 5, array ?resultType: 'WFSpotlightSearchResultType' = ["Calendar Events","Contacts","Mail","Messages","Notes","Photos","Reminders","Voice Recordings","Bookmarks"]): array
+
+enum timeDuration {
+    'hr',
+    'min',
+    'sec'
+}

--- a/actions/calendar.cherri
+++ b/actions/calendar.cherri
@@ -42,12 +42,6 @@ enum editEventDetail {
     'Attachments',
 }
 
-enum timerDuration {
-    'hr',
-    'min',
-    'sec'
-}
-
 // [Doc]: [Calendars] Add Calendar: Create a calendar with `name`.
 action 'addnewcalendar' addCalendar(text name: 'CalendarName')
 
@@ -76,7 +70,7 @@ action removeReminders(variable reminders: 'WFInputReminders')
 action 'com.apple.mobiletimer-framework.MobileTimerIntents.MTGetAlarmsIntent' getAlarms()
 
 // [Doc]: [Timers] Start Timer: Creates a new timer.
-action 'timer.start' startTimer(#timerDuration duration: 'WFDuration' = qty(0, "min"))
+action 'timer.start' startTimer(#timeDuration duration: 'WFDuration' = qty(0, "min"))
 
 // [Doc]: [Dates] Get Dates: Get dates from input.
 action 'detect.date' getDates(variable input: 'WFInput'): array

--- a/actions/music.cherri
+++ b/actions/music.cherri
@@ -84,7 +84,7 @@ enum seekBehavior {
 }
 
 // [Doc]: [Playback] Seek: Seek the currently playing media.
-action seek(#timerDuration timeInterval: 'WFTimeInterval' = qty(0, "sec"), seekBehavior behavior: 'WFSeekBehavior' = "To Time")
+action seek(#timeDuration timeInterval: 'WFTimeInterval' = qty(0, "sec"), seekBehavior behavior: 'WFSeekBehavior' = "To Time")
 
 // [Doc]: [Playback] Play Next: Add music to play next in the queue.
 action 'addmusictoupnext' playNext(variable music: 'WFMusic') {


### PR DESCRIPTION
## Summary

- Move `timerDuration` enum from `actions/calendar.cherri` to `actions/basic.cherri` (renamed `timeDuration`) so it's available to all action files
- Update references in `actions/music.cherri` and `actions/calendar.cherri`

Implements the fix described by @electrikmilk in #148 (comment).

Fixes #148