### PR TITLE
Add built binary to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+/cherri
 *.exe
 *.exe~
 *.dll


### PR DESCRIPTION
## Summary

- Add `/cherri` to `.gitignore` so the extensionless binary produced by `go build` on macOS/Linux is not tracked

The existing rules cover platform-specific extensions (`.exe`, `.dll`, `.so`, `.dylib`) but miss the default `go build` output.