### PR TITLE
Fix two parser bugs in parser.go

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -264,7 +264,11 @@ func collectUntilIgnoreStrings(ch rune) string {
 			break
 		}
 		if char == '"' {
-			insideString = prev(1) == '\\'
+			if insideString {
+				insideString = prev(1) == '\\'
+			} else {
+				insideString = true
+			}
 		}
 		collected.WriteRune(char)
 		advance()
@@ -769,7 +773,7 @@ func collectComment() {
 
 func collectMultilineComment(comment *strings.Builder) {
 	advanceTimes(2)
-	for char != 1 {
+	for char != -1 {
 		if char == '*' && next(1) == '/' {
 			break
 		}


### PR DESCRIPTION
## Summary
This PR fixes two parser bugs found in `parser.go`:

### Bug 1: collectMultilineComment incorrect EOF check (line 772)
**Problem:** The function used `char != 1` instead of `char != -1` for the end-of-file check.
- In this codebase, `-1` represents EOF (as seen in other functions like `collectUntil`, `collectObject`, etc.)
- Using `char != 1` could cause infinite loops when parsing multiline comments since `char` would never equal `1` under normal circumstances

**Fix:** Changed `for char != 1` to `for char != -1`

### Bug 2: collectUntilIgnoreStrings incorrect string escape logic (line 267)
**Problem:** The string escape handling logic `insideString = prev(1) == '\\'` was incorrect.
- When encountering a quote character (`"`), the original code sets `insideString` based solely on whether the previous character is a backslash
- This doesn't correctly handle the state machine for entering/exiting strings
- The correct behavior should be:
  - If currently inside a string: stay inside only if the quote is escaped
  - If currently outside a string: enter string mode

**Example of the bug:**
- When parsing `["hello\"world"]`, the original logic would incorrectly track the string state

**Fix:** 
```go
if insideString {
    insideString = prev(1) == '\\'  // stay inside if escaped
} else {
    insideString = true              // enter string mode
}
```

## Testing
These fixes address parser behavior for:
1. Multiline comments (`/* */`) 
2. Arrays/dictionaries containing strings with escaped quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)