### PR TITLE
Use plist omitempty flag more to use more types to build more action data as types

### DIFF
--- a/action.go
+++ b/action.go
@@ -173,14 +173,14 @@ func undefinable() bool {
 }
 
 // makeAction builds an action based on its actionDefinition and adds it to the shortcut.
-func makeAction(arguments []actionArgument, reference *map[string]any) {
+func makeAction(arguments []actionArgument, reference *WFActionReference) {
 	actionIndex++
 	// Determine identifier
 	var ident = getFullActionIdentifier()
 	// Determine parameters
 	var params = getActionParameters(arguments)
 	// Additionally add the output name and UUID of this action if provided
-	addAction(ident, attachReferenceToParams(&params, reference))
+	addAction(ident, attachReferenceToParams(params, reference))
 }
 
 // getFullActionIdentifier determines the full identifier of currentAction.

--- a/shortcut.go
+++ b/shortcut.go
@@ -14,19 +14,19 @@ type ShortcutIcon struct {
 }
 
 type Shortcut struct {
-	WFWorkflowIcon                       ShortcutIcon
-	WFWorkflowActions                    []ShortcutAction
-	WFQuickActionSurfaces                []string       `plist:",omitempty"`
-	WFWorkflowInputContentItemClasses    []string       `plist:",omitempty"`
-	WFWorkflowClientVersion              string         `plist:",omitempty"`
-	WFWorkflowMinimumClientVersion       int            `plist:",omitempty"`
-	WFWorkflowMinimumClientVersionString string         `plist:",omitempty"`
-	WFWorkflowImportQuestions            interface{}    `plist:",omitempty"`
-	WFWorkflowTypes                      []string       `plist:",omitempty"`
-	WFWorkflowOutputContentItemClasses   []string       `plist:",omitempty"`
-	WFWorkflowHasShortcutInputVariables  bool           `plist:",omitempty"`
-	WFWorkflowHasOutputFallback          bool           `plist:",omitempty"`
-	WFWorkflowNoInputBehavior            map[string]any `plist:",omitempty"`
+	WFWorkflowIcon                       ShortcutIcon     `plist:",omitempty"`
+	WFWorkflowActions                    []ShortcutAction `plist:",omitempty"`
+	WFQuickActionSurfaces                []string         `plist:",omitempty"`
+	WFWorkflowInputContentItemClasses    []string         `plist:",omitempty"`
+	WFWorkflowClientVersion              string           `plist:",omitempty"`
+	WFWorkflowMinimumClientVersion       int              `plist:",omitempty"`
+	WFWorkflowMinimumClientVersionString string           `plist:",omitempty"`
+	WFWorkflowImportQuestions            interface{}      `plist:",omitempty"`
+	WFWorkflowTypes                      []string         `plist:",omitempty"`
+	WFWorkflowOutputContentItemClasses   []string         `plist:",omitempty"`
+	WFWorkflowHasShortcutInputVariables  bool             `plist:",omitempty"`
+	WFWorkflowHasOutputFallback          bool             `plist:",omitempty"`
+	WFWorkflowNoInputBehavior            map[string]any   `plist:",omitempty"`
 }
 
 var shortcut Shortcut
@@ -170,11 +170,11 @@ type WFConditionalActionParams struct {
 }
 
 type WFMenuParams struct {
-	GroupingIdentifier string        `plist:",omitempty"`
-	WFControlFlowMode  uint64        `plist:",omitempty"`
-	WFMenuPrompt       any           `plist:",omitempty"`
-	WFMenuItems        []WFMenuItem  `plist:",omitempty"`
-	UUID               string        `plist:",omitempty"`
+	GroupingIdentifier string       `plist:",omitempty"`
+	WFControlFlowMode  uint64       `plist:",omitempty"`
+	WFMenuPrompt       any          `plist:",omitempty"`
+	WFMenuItems        []WFMenuItem `plist:",omitempty"`
+	UUID               string       `plist:",omitempty"`
 }
 
 type WFMenuItem struct {
@@ -183,10 +183,10 @@ type WFMenuItem struct {
 }
 
 type WFMenuItemParams struct {
-	GroupingIdentifier       string `plist:",omitempty"`
-	WFControlFlowMode        uint64 `plist:",omitempty"`
-	WFMenuItemAttributedTitle any   `plist:",omitempty"`
-	WFMenuItemTitle          any    `plist:",omitempty"`
+	GroupingIdentifier        string `plist:",omitempty"`
+	WFControlFlowMode         uint64 `plist:",omitempty"`
+	WFMenuItemAttributedTitle any    `plist:",omitempty"`
+	WFMenuItemTitle           any    `plist:",omitempty"`
 }
 
 type WFRepeatParams struct {

--- a/shortcut.go
+++ b/shortcut.go
@@ -144,6 +144,59 @@ type WFColorValue struct {
 	AlphaComponent            any     `plist:"alphaComponent,omitempty"`
 }
 
+type WFActionReference struct {
+	CustomOutputName string `plist:",omitempty"`
+	UUID             string `plist:",omitempty"`
+}
+
+type WFSetVariableParams struct {
+	WFVariableName      string `plist:",omitempty"`
+	WFInput             any    `plist:",omitempty"`
+	WFSerializationType string `plist:",omitempty"`
+	CustomOutputName    string `plist:",omitempty"`
+	UUID                string `plist:",omitempty"`
+}
+
+type WFConditionalActionParams struct {
+	GroupingIdentifier        string `plist:",omitempty"`
+	WFControlFlowMode         uint64 `plist:",omitempty"`
+	WFInput                   any    `plist:",omitempty"`
+	WFCondition               int    `plist:",omitempty"`
+	WFConditionalActionString any    `plist:",omitempty"`
+	WFNumberValue             any    `plist:",omitempty"`
+	WFAnotherNumber           any    `plist:",omitempty"`
+	WFConditions              any    `plist:",omitempty"`
+	UUID                      string `plist:",omitempty"`
+}
+
+type WFMenuParams struct {
+	GroupingIdentifier string        `plist:",omitempty"`
+	WFControlFlowMode  uint64        `plist:",omitempty"`
+	WFMenuPrompt       any           `plist:",omitempty"`
+	WFMenuItems        []WFMenuItem  `plist:",omitempty"`
+	UUID               string        `plist:",omitempty"`
+}
+
+type WFMenuItem struct {
+	WFItemType int `plist:",omitempty"`
+	WFValue    any `plist:",omitempty"`
+}
+
+type WFMenuItemParams struct {
+	GroupingIdentifier       string `plist:",omitempty"`
+	WFControlFlowMode        uint64 `plist:",omitempty"`
+	WFMenuItemAttributedTitle any   `plist:",omitempty"`
+	WFMenuItemTitle          any    `plist:",omitempty"`
+}
+
+type WFRepeatParams struct {
+	GroupingIdentifier string `plist:",omitempty"`
+	WFControlFlowMode  uint64 `plist:",omitempty"`
+	WFRepeatCount      any    `plist:",omitempty"`
+	WFInput            any    `plist:",omitempty"`
+	UUID               string `plist:",omitempty"`
+}
+
 var uuids map[string]string
 
 type dictDataType int

--- a/shortcut.go
+++ b/shortcut.go
@@ -149,54 +149,6 @@ type WFActionReference struct {
 	UUID             string `plist:",omitempty"`
 }
 
-type WFSetVariableParams struct {
-	WFVariableName      string `plist:",omitempty"`
-	WFInput             any    `plist:",omitempty"`
-	WFSerializationType string `plist:",omitempty"`
-	CustomOutputName    string `plist:",omitempty"`
-	UUID                string `plist:",omitempty"`
-}
-
-type WFConditionalActionParams struct {
-	GroupingIdentifier        string `plist:",omitempty"`
-	WFControlFlowMode         uint64 `plist:",omitempty"`
-	WFInput                   any    `plist:",omitempty"`
-	WFCondition               int    `plist:",omitempty"`
-	WFConditionalActionString any    `plist:",omitempty"`
-	WFNumberValue             any    `plist:",omitempty"`
-	WFAnotherNumber           any    `plist:",omitempty"`
-	WFConditions              any    `plist:",omitempty"`
-	UUID                      string `plist:",omitempty"`
-}
-
-type WFMenuParams struct {
-	GroupingIdentifier string       `plist:",omitempty"`
-	WFControlFlowMode  uint64       `plist:",omitempty"`
-	WFMenuPrompt       any          `plist:",omitempty"`
-	WFMenuItems        []WFMenuItem `plist:",omitempty"`
-	UUID               string       `plist:",omitempty"`
-}
-
-type WFMenuItem struct {
-	WFItemType int `plist:",omitempty"`
-	WFValue    any `plist:",omitempty"`
-}
-
-type WFMenuItemParams struct {
-	GroupingIdentifier        string `plist:",omitempty"`
-	WFControlFlowMode         uint64 `plist:",omitempty"`
-	WFMenuItemAttributedTitle any    `plist:",omitempty"`
-	WFMenuItemTitle           any    `plist:",omitempty"`
-}
-
-type WFRepeatParams struct {
-	GroupingIdentifier string `plist:",omitempty"`
-	WFControlFlowMode  uint64 `plist:",omitempty"`
-	WFRepeatCount      any    `plist:",omitempty"`
-	WFInput            any    `plist:",omitempty"`
-	UUID               string `plist:",omitempty"`
-}
-
 var uuids map[string]string
 
 type dictDataType int

--- a/shortcut.go
+++ b/shortcut.go
@@ -9,84 +9,139 @@ package main
 */
 
 type ShortcutIcon struct {
-	WFWorkflowIconGlyphNumber int64
-	WFWorkflowIconStartColor  int
+	WFWorkflowIconGlyphNumber int64 `plist:",omitempty"`
+	WFWorkflowIconStartColor  int   `plist:",omitempty"`
 }
 
 type Shortcut struct {
 	WFWorkflowIcon                       ShortcutIcon
 	WFWorkflowActions                    []ShortcutAction
-	WFQuickActionSurfaces                []string
-	WFWorkflowInputContentItemClasses    []string
-	WFWorkflowClientVersion              string
-	WFWorkflowMinimumClientVersion       int
-	WFWorkflowMinimumClientVersionString string
-	WFWorkflowImportQuestions            interface{}
-	WFWorkflowTypes                      []string
-	WFWorkflowOutputContentItemClasses   []string
-	WFWorkflowHasShortcutInputVariables  bool
-	WFWorkflowHasOutputFallback          bool
-	WFWorkflowNoInputBehavior            map[string]any
+	WFQuickActionSurfaces                []string       `plist:",omitempty"`
+	WFWorkflowInputContentItemClasses    []string       `plist:",omitempty"`
+	WFWorkflowClientVersion              string         `plist:",omitempty"`
+	WFWorkflowMinimumClientVersion       int            `plist:",omitempty"`
+	WFWorkflowMinimumClientVersionString string         `plist:",omitempty"`
+	WFWorkflowImportQuestions            interface{}    `plist:",omitempty"`
+	WFWorkflowTypes                      []string       `plist:",omitempty"`
+	WFWorkflowOutputContentItemClasses   []string       `plist:",omitempty"`
+	WFWorkflowHasShortcutInputVariables  bool           `plist:",omitempty"`
+	WFWorkflowHasOutputFallback          bool           `plist:",omitempty"`
+	WFWorkflowNoInputBehavior            map[string]any `plist:",omitempty"`
 }
 
 var shortcut Shortcut
 
 type ShortcutAction struct {
 	WFWorkflowActionIdentifier string
-	WFWorkflowActionParameters map[string]any
+	WFWorkflowActionParameters map[string]any `plist:",omitempty"`
 }
 
 type Value struct {
-	Type                        string
-	VariableName                string
-	OutputUUID                  string
-	OutputName                  string
-	Value                       any
-	Variable                    any
-	WFDictionaryFieldValueItems []WFDictionaryFieldValueItem
-	AttachmentsByRange          map[string]Value
-	String                      string
-	Aggrandizements             []Aggrandizement
-	Prompt                      string
+	Type                        string                       `plist:",omitempty"`
+	VariableName                string                       `plist:",omitempty"`
+	OutputUUID                  string                       `plist:",omitempty"`
+	OutputName                  string                       `plist:",omitempty"`
+	Value                       any                          `plist:",omitempty"`
+	Variable                    any                          `plist:",omitempty"`
+	WFDictionaryFieldValueItems []WFDictionaryFieldValueItem `plist:",omitempty"`
+	AttachmentsByRange          map[string]Value             `plist:",omitempty"`
+	String                      string                       `plist:",omitempty"`
+	Aggrandizements             []Aggrandizement             `plist:",omitempty"`
+	Prompt                      string                       `plist:",omitempty"`
 }
 
 type Aggrandizement struct {
-	Type              string
-	CoercionItemClass string
-	DictionaryKey     string
-	PropertyName      string
-	PropertyUserInfo  any
+	Type              string `plist:",omitempty"`
+	CoercionItemClass string `plist:",omitempty"`
+	DictionaryKey     string `plist:",omitempty"`
+	PropertyName      string `plist:",omitempty"`
+	PropertyUserInfo  any    `plist:",omitempty"`
 }
 
 type WFDictionaryFieldValueItem struct {
-	WFKey      any
-	WFItemType int
-	WFValue    any
+	WFKey      any `plist:",omitempty"`
+	WFItemType int `plist:",omitempty"`
+	WFValue    any `plist:",omitempty"`
 }
 
 type WFValue struct {
-	Value               any
-	String              string
-	WFSerializationType string
+	Value               any    `plist:",omitempty"`
+	String              string `plist:",omitempty"`
+	WFSerializationType string `plist:",omitempty"`
 }
 
 type WFInput struct {
-	Value Value
+	Value Value `plist:",omitempty"`
 }
 
 type WFContactFieldValue struct {
-	EntryType       int
-	SerializedEntry map[string]interface{}
+	EntryType       int                    `plist:",omitempty"`
+	SerializedEntry map[string]interface{} `plist:",omitempty"`
 }
 
 type SizeValue struct {
-	Unit      string
-	Magnitude string
+	Unit      string `plist:",omitempty"`
+	Magnitude string `plist:",omitempty"`
 }
 
 type WFMeasurementUnit struct {
-	WFNSUnitSymbol any
-	Value          SizeValue
+	WFNSUnitSymbol any       `plist:",omitempty"`
+	Value          SizeValue `plist:",omitempty"`
+}
+
+type WFTextTokenAttachment struct {
+	Value               Value  `plist:",omitempty"`
+	WFSerializationType string `plist:",omitempty"`
+}
+
+type WFTextTokenString struct {
+	Value               WFTextTokenStringValue `plist:",omitempty"`
+	WFSerializationType string                 `plist:",omitempty"`
+}
+
+type WFTextTokenStringValue struct {
+	AttachmentsByRange map[string]Value `plist:"attachmentsByRange,omitempty"`
+	String             string           `plist:"string,omitempty"`
+}
+
+type WFDictionaryFieldValue struct {
+	Value               WFDictionaryFieldValueWrapper `plist:",omitempty"`
+	WFSerializationType string                        `plist:",omitempty"`
+}
+
+type WFDictionaryFieldValueWrapper struct {
+	WFDictionaryFieldValueItems []WFDictionaryFieldValueItem `plist:",omitempty"`
+}
+
+type WFContentPredicateTableTemplate struct {
+	Value               WFConditionValue `plist:",omitempty"`
+	WFSerializationType string           `plist:",omitempty"`
+}
+
+type WFConditionValue struct {
+	WFActionParameterFilterPrefix    int                `plist:",omitempty"`
+	WFActionParameterFilterTemplates []WFConditionParam `plist:",omitempty"`
+}
+
+type WFConditionParam struct {
+	WFCondition               int             `plist:",omitempty"`
+	WFInput                   WFInputVariable `plist:",omitempty"`
+	WFConditionalActionString any             `plist:",omitempty"`
+	WFNumberValue             any             `plist:",omitempty"`
+	WFAnotherNumber           any             `plist:",omitempty"`
+}
+
+type WFInputVariable struct {
+	Type     string                `plist:",omitempty"`
+	Variable WFTextTokenAttachment `plist:",omitempty"`
+}
+
+type WFColorValue struct {
+	WFColorRepresentationType string  `plist:",omitempty"`
+	RedComponent              float64 `plist:"redComponent,omitempty"`
+	GreenComponent            float64 `plist:"greenComponent,omitempty"`
+	BlueComponent             float64 `plist:"blueComponent,omitempty"`
+	AlphaComponent            any     `plist:"alphaComponent,omitempty"`
 }
 
 var uuids map[string]string

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -950,21 +950,13 @@ func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *
 			valueType: *typeOf,
 			value:     value,
 		}, String)
-		if key == "WFAnotherNumber" {
-			conditionParam.WFAnotherNumber = paramVal
-		} else {
-			conditionParam.WFConditionalActionString = paramVal
-		}
+		conditionIntegerValue(conditionParam, key, paramVal)
 	case Integer:
 		var paramVal = paramValue(actionArgument{
 			valueType: *typeOf,
 			value:     value,
-		}, String)
-		if key == "WFAnotherNumber" {
-			conditionParam.WFAnotherNumber = paramVal
-		} else {
-			conditionParam.WFNumberValue = paramVal
-		}
+		}, Integer)
+		conditionIntegerValue(conditionParam, key, paramVal)
 	case Bool:
 		var boolNumber = "0"
 		if value == true {
@@ -974,11 +966,7 @@ func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *
 			valueType: Integer,
 			value:     boolNumber,
 		}, Integer)
-		if key == "WFAnotherNumber" {
-			conditionParam.WFAnotherNumber = paramVal
-		} else {
-			conditionParam.WFNumberValue = paramVal
-		}
+		conditionIntegerValue(conditionParam, key, paramVal)
 	case Variable:
 		conditionalParameterVariable(conditionParam, key, value)
 	}
@@ -989,18 +977,26 @@ func conditionalParameterVariable(conditionParam *WFConditionParam, key string, 
 	var variable = variables[condVarValue.value.(string)]
 	switch variable.valueType {
 	case Integer:
-		if key == "WFAnotherNumber" {
-			conditionParam.WFAnotherNumber = variableValue(condVarValue)
-		} else {
-			conditionParam.WFNumberValue = variableValue(condVarValue)
-		}
+		conditionIntegerValue(conditionParam, key, variableValue(condVarValue))
 	default:
 		var paramVal = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
-		if key == "WFAnotherNumber" {
-			conditionParam.WFAnotherNumber = paramVal
-		} else {
-			conditionParam.WFConditionalActionString = paramVal
-		}
+		conditionStringValue(conditionParam, key, paramVal)
+	}
+}
+
+func conditionStringValue(param *WFConditionParam, key string, value any) {
+	if key == "WFAnotherNumber" {
+		param.WFAnotherNumber = value
+	} else {
+		param.WFConditionalActionString = value
+	}
+}
+
+func conditionIntegerValue(param *WFConditionParam, key string, value any) {
+	if key == "WFAnotherNumber" {
+		param.WFAnotherNumber = value
+	} else {
+		param.WFNumberValue = value
 	}
 }
 

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -995,7 +995,7 @@ func conditionalParameterVariable(conditionParam *WFConditionParam, key string, 
 			conditionParam.WFNumberValue = variableValue(condVarValue)
 		}
 	default:
-		paramVal := attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
+		var paramVal = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
 		if key == "WFAnotherNumber" {
 			conditionParam.WFAnotherNumber = paramVal
 		} else {

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -94,7 +94,7 @@ func generateActions() {
 			if tokenAction.ident == "rawAction" && len(tokenAction.args) > 0 {
 				currentAction.overrideIdentifier = getArgValue(tokenAction.args[0]).(string)
 			}
-			makeAction(tokenAction.args, &map[string]any{})
+			makeAction(tokenAction.args, &WFActionReference{})
 		case Repeat:
 			makeRepeatAction(&t)
 		case RepeatWithEach:
@@ -169,9 +169,9 @@ func makeVariableInput(t *token, params map[string]any) {
 }
 
 func makeVariableValueAction(token *token, customOutputName *string, varUUID *string) {
-	var reference = map[string]any{
-		"CustomOutputName": *customOutputName,
-		"UUID":             *varUUID,
+	var reference = WFActionReference{
+		CustomOutputName: *customOutputName,
+		UUID:             *varUUID,
 	}
 
 	if (token.typeof == AddTo || token.typeof == SubFrom || token.typeof == MultiplyBy || token.typeof == DivideBy) &&
@@ -184,7 +184,7 @@ func makeVariableValueAction(token *token, customOutputName *string, varUUID *st
 	makeVariableValue(&reference, token.valueType, &token.value)
 }
 
-func makeVariableValue(reference *map[string]any, valueType tokenType, value *any) {
+func makeVariableValue(reference *WFActionReference, valueType tokenType, value *any) {
 	switch valueType {
 	case Integer, Float:
 		makeIntValue(reference, value)
@@ -202,42 +202,42 @@ func makeVariableValue(reference *map[string]any, valueType tokenType, value *an
 		setCurrentAction(action.ident, actions[action.ident])
 		makeAction(action.args, reference)
 	case Dict:
-		addStdAction("dictionary", attachReferenceToParams(&map[string]any{
+		addStdAction("dictionary", attachReferenceToParams(map[string]any{
 			"WFItems": makeDictionaryValue(value),
 		}, reference))
 	}
 }
 
-func makeIntValue(reference *map[string]any, value *any) {
-	addStdAction("number", attachReferenceToParams(&map[string]any{
+func makeIntValue(reference *WFActionReference, value *any) {
+	addStdAction("number", attachReferenceToParams(map[string]any{
 		"WFNumberActionNumber": *value,
 	}, reference))
 }
 
-func makeStringValue(reference *map[string]any, value *any) {
-	addStdAction("gettext", attachReferenceToParams(&map[string]any{
+func makeStringValue(reference *WFActionReference, value *any) {
+	addStdAction("gettext", attachReferenceToParams(map[string]any{
 		"WFTextActionText": attachmentValues(fmt.Sprintf("%s", *value)),
 	}, reference))
 }
 
-func makeRawStringValue(reference *map[string]any, value *any) {
-	addStdAction("gettext", attachReferenceToParams(&map[string]any{
+func makeRawStringValue(reference *WFActionReference, value *any) {
+	addStdAction("gettext", attachReferenceToParams(map[string]any{
 		"WFTextActionText": fmt.Sprintf("%s", *value),
 	}, reference))
 }
 
-func makeBoolValue(reference *map[string]any, value *any) {
+func makeBoolValue(reference *WFActionReference, value *any) {
 	var boolValue = "0"
 	if *value == true {
 		boolValue = "1"
 	}
 
-	addStdAction("number", attachReferenceToParams(&map[string]any{
+	addStdAction("number", attachReferenceToParams(map[string]any{
 		"WFNumberActionNumber": boolValue,
 	}, reference))
 }
 
-func makeExpressionValue(reference *map[string]any, value *any) {
+func makeExpressionValue(reference *WFActionReference, value *any) {
 	var expression = fmt.Sprintf("%s", *value)
 	var expressionParts = strings.Split(expression, " ")
 	if len(expressionParts) == 3 && containsTokens(&expression, Plus, Minus, Multiply, Divide) {
@@ -245,12 +245,12 @@ func makeExpressionValue(reference *map[string]any, value *any) {
 		return
 	}
 
-	addStdAction("calculateexpression", attachReferenceToParams(&map[string]any{
+	addStdAction("calculateexpression", attachReferenceToParams(map[string]any{
 		"Input": attachmentValues(expression),
 	}, reference))
 }
 
-func makeMathValue(reference *map[string]any, expression string, expressionParts []string) {
+func makeMathValue(reference *WFActionReference, expression string, expressionParts []string) {
 	var operandOne string
 	var operandTwo string
 
@@ -267,7 +267,7 @@ func makeMathValue(reference *map[string]any, expression string, expressionParts
 		operation = "÷"
 	}
 
-	addStdAction("math", attachReferenceToParams(&map[string]any{
+	addStdAction("math", attachReferenceToParams(map[string]any{
 		"WFMathOperation": operation,
 		"WFInput":         attachmentValues(operandOne),
 		"WFMathOperand":   attachmentValues(operandTwo),
@@ -285,7 +285,7 @@ func makeDictionaryValue(value *any) WFDictionaryFieldValue {
 	}
 }
 
-func variableValueModifier(token *token, reference *map[string]any) {
+func variableValueModifier(token *token, reference *WFActionReference) {
 	var valueType = token.valueType
 	if valueType == Variable {
 		var variable = token.value.(varValue)
@@ -304,7 +304,7 @@ func variableValueModifier(token *token, reference *map[string]any) {
 		case DivideBy:
 			operation = "÷"
 		}
-		addStdAction("math", attachReferenceToParams(&map[string]any{
+		addStdAction("math", attachReferenceToParams(map[string]any{
 			"WFMathOperand": paramValue(actionArgument{
 				valueType: token.valueType,
 				value:     token.value,
@@ -319,7 +319,7 @@ func variableValueModifier(token *token, reference *map[string]any) {
 		var varInput = token.value.(string)
 		wrapVariableReference(&varInput)
 
-		addStdAction("gettext", attachReferenceToParams(&map[string]any{
+		addStdAction("gettext", attachReferenceToParams(map[string]any{
 			"WFTextActionText": paramValue(actionArgument{
 				valueType: String,
 				value:     fmt.Sprintf("{%s}%s", token.ident, varInput),
@@ -328,10 +328,14 @@ func variableValueModifier(token *token, reference *map[string]any) {
 	}
 }
 
-func attachReferenceToParams(params *map[string]any, reference *map[string]any) *map[string]any {
-	maps.Copy(*params, *reference)
-
-	return params
+func attachReferenceToParams(params map[string]any, reference *WFActionReference) *map[string]any {
+	if reference.CustomOutputName != "" {
+		params["CustomOutputName"] = reference.CustomOutputName
+	}
+	if reference.UUID != "" {
+		params["UUID"] = reference.UUID
+	}
+	return &params
 }
 
 func inputValue(name string, varUUID string) WFTextTokenAttachment {

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -432,7 +432,7 @@ func variableValue(variable varValue) WFTextTokenAttachment {
 	}
 }
 
-type inlineVar struct {
+type inlineVariable struct {
 	identifier string
 	col        int
 	getAs      string
@@ -446,7 +446,7 @@ type attachmentVariable struct {
 }
 
 var varPositions map[string]Value
-var inlineVars []inlineVar
+var inlineVariables []inlineVariable
 var varIndex []attachmentVariable
 
 func attachmentValues(str string) any {
@@ -455,7 +455,7 @@ func attachmentValues(str string) any {
 	}
 
 	varPositions = make(map[string]Value)
-	inlineVars = []inlineVar{}
+	inlineVariables = []inlineVariable{}
 	varIndex = []attachmentVariable{}
 
 	var noVarString = collectInlineVariables(&str)
@@ -471,58 +471,52 @@ func attachmentValues(str string) any {
 }
 
 func makeAttachmentValues() {
-	for _, stringVar := range inlineVars {
-		var storedVar varValue
-		if g, global := globals[stringVar.identifier]; global {
-			isInputVariable(stringVar.identifier)
-			storedVar = g
-			stringVar.identifier = g.value.(string)
-		} else if v, found := variables[stringVar.identifier]; found {
-			storedVar = v
-		} else {
-			exit(fmt.Sprintf("Undefined reference '%s'", stringVar.identifier))
+	for _, inlineVar := range inlineVariables {
+		var varValue, found = getVariableValue(inlineVar.identifier)
+		if !found {
+			exit(fmt.Sprintf("Undefined reference '%s'", inlineVar.identifier))
 		}
-		var variable = variables[stringVar.identifier]
-		var varUUID = uuids[stringVar.identifier]
-		var varValue Value
+
+		var attachmentValue Value
+		var aggrandizements []Aggrandizement
 		var varType = "Variable"
-		var aggr []Aggrandizement
-		if storedVar.variableType != "" {
-			varType = storedVar.variableType
+		if varValue.variableType != "" {
+			varType = varValue.variableType
 		}
-		if !variable.constant {
-			varValue = Value{
-				VariableName: stringVar.identifier,
+		if !varValue.constant {
+			attachmentValue = Value{
+				VariableName: inlineVar.identifier,
 				Type:         varType,
 			}
 		} else {
-			varValue = Value{
-				OutputName: stringVar.identifier,
+			var varUUID = uuids[inlineVar.identifier]
+			attachmentValue = Value{
+				OutputName: inlineVar.identifier,
 				OutputUUID: varUUID,
 				Type:       "ActionOutput",
 			}
 		}
 
-		if stringVar.getAs != "" {
-			aggr = append(aggr, makeAggrandizement(&variable.valueType, &variable, stringVar.getAs))
+		if inlineVar.getAs != "" {
+			aggrandizements = append(aggrandizements, makeAggrandizement(&varValue.valueType, varValue, inlineVar.getAs))
 		}
-		if stringVar.coerce != "" {
-			if contentItem, found := contentItems[stringVar.coerce]; found {
-				aggr = append(aggr, Aggrandizement{
+		if inlineVar.coerce != "" {
+			if contentItem, found := contentItems[inlineVar.coerce]; found {
+				aggrandizements = append(aggrandizements, Aggrandizement{
 					Type:              "WFCoercionVariableAggrandizement",
 					CoercionItemClass: contentItem,
 				})
 			} else {
-				var list = makeKeyList("Available content item types:", contentItems, stringVar.coerce)
-				parserError(fmt.Sprintf("Invalid content item for type coerce '%s'\n\n%s\n", stringVar.coerce, list))
+				var list = makeKeyList("Available content item types:", contentItems, inlineVar.coerce)
+				parserError(fmt.Sprintf("Invalid content item for type coerce '%s'\n\n%s\n", inlineVar.coerce, list))
 			}
 		}
-		if stringVar.getAs != "" || stringVar.coerce != "" {
-			varValue.Aggrandizements = aggr
+		if inlineVar.getAs != "" || inlineVar.coerce != "" {
+			attachmentValue.Aggrandizements = aggrandizements
 		}
 
-		var positionsKey = fmt.Sprintf("{%d, 1}", stringVar.col)
-		varPositions[positionsKey] = varValue
+		var positionsKey = fmt.Sprintf("{%d, 1}", inlineVar.col)
+		varPositions[positionsKey] = attachmentValue
 	}
 }
 
@@ -552,15 +546,15 @@ func makeAggrandizement(valueType *tokenType, variable *varValue, getAs string) 
 
 const utf16BMPThreshold = 0x10000
 
-// mapInlineVars finds occurrences of ObjectReplaceChar and adds them to inlineVars to map the inline variables in noVarString.
+// mapInlineVariables finds occurrences of ObjectReplaceChar and adds them to inlineVariables to map the inline variables in noVarString.
 // Accounts for UTF-16 characters with code units which require the inline variable position to be doubled (e.g. emoji, bold text).
-func mapInlineVars(noVarString *string) {
+func mapInlineVariables(noVarString *string) {
 	var variableIdx int
 	var charPos = 0
 
 	for _, r := range *noVarString {
 		if r == ObjectReplaceChar {
-			inlineVars = append(inlineVars, inlineVar{
+			inlineVariables = append(inlineVariables, inlineVariable{
 				identifier: varIndex[variableIdx].identifier,
 				col:        charPos,
 				getAs:      varIndex[variableIdx].getAs,
@@ -603,7 +597,7 @@ func collectInlineVariables(str *string) (noVarString string) {
 		noVarString = replaceVarRegex.ReplaceAllString(*str, ObjectReplaceCharStr)
 	}
 
-	mapInlineVars(&noVarString)
+	mapInlineVariables(&noVarString)
 	return
 }
 

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -958,9 +958,9 @@ func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *
 		}, Integer)
 		conditionIntegerValue(conditionParam, key, paramVal)
 	case Bool:
-		var boolNumber = "0"
+		var boolNumber = 0
 		if value == true {
-			boolNumber = "1"
+			boolNumber = 1
 		}
 		var paramVal = paramValue(actionArgument{
 			valueType: Integer,
@@ -1021,9 +1021,9 @@ func conditionalParameterLegacy(key string, conditionalParams map[string]any, ty
 			value:     value,
 		}, String)
 	case Bool:
-		var boolNumber = "0"
+		var boolNumber = 0
 		if value == true {
-			boolNumber = "1"
+			boolNumber = 1
 		}
 		conditionalParams[key] = paramValue(actionArgument{
 			valueType: Integer,

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -946,7 +946,7 @@ func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate 
 func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *tokenType, value any) {
 	switch *typeOf {
 	case String:
-		paramVal := paramValue(actionArgument{
+		var paramVal = paramValue(actionArgument{
 			valueType: *typeOf,
 			value:     value,
 		}, String)
@@ -956,7 +956,7 @@ func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *
 			conditionParam.WFConditionalActionString = paramVal
 		}
 	case Integer:
-		paramVal := paramValue(actionArgument{
+		var paramVal = paramValue(actionArgument{
 			valueType: *typeOf,
 			value:     value,
 		}, String)
@@ -970,7 +970,7 @@ func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *
 		if value == true {
 			boolNumber = "1"
 		}
-		paramVal := paramValue(actionArgument{
+		var paramVal = paramValue(actionArgument{
 			valueType: Integer,
 			value:     boolNumber,
 		}, Integer)

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -445,7 +445,7 @@ type attachmentVariable struct {
 	coerce     string
 }
 
-var varPositions map[string]any
+var varPositions map[string]Value
 var inlineVars []inlineVar
 var varIndex []attachmentVariable
 
@@ -454,7 +454,7 @@ func attachmentValues(str string) any {
 		return str
 	}
 
-	varPositions = make(map[string]any)
+	varPositions = make(map[string]Value)
 	inlineVars = []inlineVar{}
 	varIndex = []attachmentVariable{}
 
@@ -463,23 +463,11 @@ func attachmentValues(str string) any {
 
 	return WFTextTokenString{
 		Value: WFTextTokenStringValue{
-			AttachmentsByRange: convertMapToValueMap(varPositions),
+			AttachmentsByRange: varPositions,
 			String:             noVarString,
 		},
 		WFSerializationType: "WFTextTokenString",
 	}
-}
-
-func convertMapToValueMap(m map[string]any) map[string]Value {
-	result := make(map[string]Value)
-	for k, v := range m {
-		if valueMap, ok := v.(map[string]any); ok {
-			var value Value
-			mapToStruct(valueMap, &value)
-			result[k] = value
-		}
-	}
-	return result
 }
 
 func makeAttachmentValues() {
@@ -496,22 +484,22 @@ func makeAttachmentValues() {
 		}
 		var variable = variables[stringVar.identifier]
 		var varUUID = uuids[stringVar.identifier]
-		var varValue map[string]any
+		var varValue Value
 		var varType = "Variable"
-		var aggr []map[string]string
+		var aggr []Aggrandizement
 		if storedVar.variableType != "" {
 			varType = storedVar.variableType
 		}
 		if !variable.constant {
-			varValue = map[string]any{
-				"VariableName": stringVar.identifier,
-				"Type":         varType,
+			varValue = Value{
+				VariableName: stringVar.identifier,
+				Type:         varType,
 			}
 		} else {
-			varValue = map[string]any{
-				"OutputName": stringVar.identifier,
-				"OutputUUID": varUUID,
-				"Type":       "ActionOutput",
+			varValue = Value{
+				OutputName: stringVar.identifier,
+				OutputUUID: varUUID,
+				Type:       "ActionOutput",
 			}
 		}
 
@@ -520,9 +508,9 @@ func makeAttachmentValues() {
 		}
 		if stringVar.coerce != "" {
 			if contentItem, found := contentItems[stringVar.coerce]; found {
-				aggr = append(aggr, map[string]string{
-					"Type":              "WFCoercionVariableAggrandizement",
-					"CoercionItemClass": contentItem,
+				aggr = append(aggr, Aggrandizement{
+					Type:              "WFCoercionVariableAggrandizement",
+					CoercionItemClass: contentItem,
 				})
 			} else {
 				var list = makeKeyList("Available content item types:", contentItems, stringVar.coerce)
@@ -530,7 +518,7 @@ func makeAttachmentValues() {
 			}
 		}
 		if stringVar.getAs != "" || stringVar.coerce != "" {
-			varValue["Aggrandizements"] = aggr
+			varValue.Aggrandizements = aggr
 		}
 
 		var positionsKey = fmt.Sprintf("{%d, 1}", stringVar.col)
@@ -538,26 +526,25 @@ func makeAttachmentValues() {
 	}
 }
 
-func makeAggrandizement(valueType *tokenType, variable *varValue, getAs string) map[string]string {
-	var aggrandizement = make(map[string]string)
+func makeAggrandizement(valueType *tokenType, variable *varValue, getAs string) (aggrandizement Aggrandizement) {
 	switch *valueType {
 	case Dict:
-		aggrandizement["Type"] = "WFDictionaryValueVariableAggrandizement"
+		aggrandizement.Type = "WFDictionaryValueVariableAggrandizement"
 	case Action:
 		var variableAction = *variable.value.(action).def
 		if variableAction.outputType == Dict {
-			aggrandizement["Type"] = "WFDictionaryValueVariableAggrandizement"
+			aggrandizement.Type = "WFDictionaryValueVariableAggrandizement"
 		} else {
-			aggrandizement["Type"] = "WFPropertyVariableAggrandizement"
+			aggrandizement.Type = "WFPropertyVariableAggrandizement"
 		}
 	default:
-		aggrandizement["Type"] = "WFPropertyVariableAggrandizement"
+		aggrandizement.Type = "WFPropertyVariableAggrandizement"
 	}
 
-	if aggrandizement["Type"] == "WFDictionaryValueVariableAggrandizement" {
-		aggrandizement["DictionaryKey"] = getAs
+	if aggrandizement.Type == "WFDictionaryValueVariableAggrandizement" {
+		aggrandizement.DictionaryKey = getAs
 	} else {
-		aggrandizement["PropertyName"] = getAs
+		aggrandizement.PropertyName = getAs
 	}
 
 	return aggrandizement

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -276,12 +276,12 @@ func makeMathValue(reference *map[string]any, expression string, expressionParts
 	return
 }
 
-func makeDictionaryValue(value *any) map[string]any {
-	return map[string]any{
-		"Value": map[string]any{
-			"WFDictionaryFieldValueItems": makeDictionary(*value),
+func makeDictionaryValue(value *any) WFDictionaryFieldValue {
+	return WFDictionaryFieldValue{
+		Value: WFDictionaryFieldValueWrapper{
+			WFDictionaryFieldValueItems: makeDictionary(*value),
 		},
-		"WFSerializationType": "WFDictionaryFieldValue",
+		WFSerializationType: "WFDictionaryFieldValue",
 	}
 }
 
@@ -334,39 +334,39 @@ func attachReferenceToParams(params *map[string]any, reference *map[string]any) 
 	return params
 }
 
-func inputValue(name string, varUUID string) map[string]any {
-	var value = make(map[string]any)
+func inputValue(name string, varUUID string) WFTextTokenAttachment {
+	var value = Value{}
 
 	if varUUID != "" {
-		value["OutputUUID"] = varUUID
+		value.OutputUUID = varUUID
 	}
 
 	if variable, found := variables[name]; found {
 		if !variable.repeatItem && (variable.constant && variable.valueType != Variable) {
-			value["OutputName"] = name
-			value["Type"] = "ActionOutput"
+			value.OutputName = name
+			value.Type = "ActionOutput"
 		} else {
-			value["VariableName"] = name
-			value["Type"] = "Variable"
+			value.VariableName = name
+			value.Type = "Variable"
 		}
 	} else if global, found := globals[name]; found {
 		isInputVariable(name)
-		value["Type"] = global.variableType
+		value.Type = global.variableType
 	} else {
-		value["OutputName"] = name
-		value["Type"] = "ActionOutput"
+		value.OutputName = name
+		value.Type = "ActionOutput"
 	}
 
-	return map[string]any{
-		"Value":               value,
-		"WFSerializationType": "WFTextTokenAttachment",
+	return WFTextTokenAttachment{
+		Value:               value,
+		WFSerializationType: "WFTextTokenAttachment",
 	}
 }
 
-func variableValue(variable varValue) map[string]any {
+func variableValue(variable varValue) WFTextTokenAttachment {
 	var identifier = variable.value.(string)
 	var variableReference varValue
-	var aggrandizements []map[string]any
+	var aggrandizements []Aggrandizement
 	if global, found := globals[identifier]; found {
 		isInputVariable(identifier)
 		variable.variableType = global.variableType
@@ -381,23 +381,23 @@ func variableValue(variable varValue) map[string]any {
 			refValueType = variableReference.valueType
 		}
 		if refValueType == Dict {
-			aggrandizements = append(aggrandizements, map[string]any{
-				"Type":          "WFDictionaryValueVariableAggrandizement",
-				"DictionaryKey": variable.getAs,
+			aggrandizements = append(aggrandizements, Aggrandizement{
+				Type:          "WFDictionaryValueVariableAggrandizement",
+				DictionaryKey: variable.getAs,
 			})
 		} else {
-			aggrandizements = append(aggrandizements, map[string]any{
-				"PropertyUserInfo": 0,
-				"Type":             "WFPropertyVariableAggrandizement",
-				"PropertyName":     variable.getAs,
+			aggrandizements = append(aggrandizements, Aggrandizement{
+				PropertyUserInfo: 0,
+				Type:             "WFPropertyVariableAggrandizement",
+				PropertyName:     variable.getAs,
 			})
 		}
 	}
 	if variable.coerce != "" {
 		if contentItem, found := contentItems[variable.coerce]; found {
-			aggrandizements = append(aggrandizements, map[string]any{
-				"Type":              "WFCoercionVariableAggrandizement",
-				"CoercionItemClass": contentItem,
+			aggrandizements = append(aggrandizements, Aggrandizement{
+				Type:              "WFCoercionVariableAggrandizement",
+				CoercionItemClass: contentItem,
 			})
 		}
 	}
@@ -405,26 +405,26 @@ func variableValue(variable varValue) map[string]any {
 	if variable.variableType != "" {
 		varType = variable.variableType
 	}
-	var varValue = make(map[string]any)
+	var varValue = Value{}
 	if variable.constant {
 		var varUUID = uuids[identifier]
-		varValue["OutputName"] = identifier
-		varValue["OutputUUID"] = varUUID
-		varValue["Type"] = "ActionOutput"
+		varValue.OutputName = identifier
+		varValue.OutputUUID = varUUID
+		varValue.Type = "ActionOutput"
 	} else {
-		varValue["VariableName"] = identifier
-		varValue["Type"] = varType
+		varValue.VariableName = identifier
+		varValue.Type = varType
 		if varType == Ask && variable.prompt != "" {
-			varValue["Prompt"] = variable.prompt
+			varValue.Prompt = variable.prompt
 		}
 	}
 	if len(aggrandizements) > 0 {
-		varValue["Aggrandizements"] = aggrandizements
+		varValue.Aggrandizements = aggrandizements
 	}
 
-	return map[string]any{
-		"Value":               varValue,
-		"WFSerializationType": "WFTextTokenAttachment",
+	return WFTextTokenAttachment{
+		Value:               varValue,
+		WFSerializationType: "WFTextTokenAttachment",
 	}
 }
 
@@ -457,13 +457,25 @@ func attachmentValues(str string) any {
 	var noVarString = collectInlineVariables(&str)
 	makeAttachmentValues()
 
-	return map[string]any{
-		"Value": map[string]any{
-			"attachmentsByRange": varPositions,
-			"string":             noVarString,
+	return WFTextTokenString{
+		Value: WFTextTokenStringValue{
+			AttachmentsByRange: convertMapToValueMap(varPositions),
+			String:             noVarString,
 		},
-		"WFSerializationType": "WFTextTokenString",
+		WFSerializationType: "WFTextTokenString",
 	}
+}
+
+func convertMapToValueMap(m map[string]any) map[string]Value {
+	result := make(map[string]Value)
+	for k, v := range m {
+		if valueMap, ok := v.(map[string]any); ok {
+			var value Value
+			mapToStruct(valueMap, &value)
+			result[k] = value
+		}
+	}
+	return result
 }
 
 func makeAttachmentValues() {
@@ -646,12 +658,12 @@ func paramValue(arg actionArgument, handleAs tokenType) any {
 		return arg.value
 	case Color:
 		var colorArgs = arg.value.([]actionArgument)
-		return map[string]any{
-			"WFColorRepresentationType": "WFColorRepresentationTypeCGColor",
-			"redComponent":              colorArgs[0].value.(float64),
-			"greenComponent":            colorArgs[1].value.(float64),
-			"blueComponent":             colorArgs[2].value.(float64),
-			"alphaComponent":            colorArgs[3].value,
+		return WFColorValue{
+			WFColorRepresentationType: "WFColorRepresentationTypeCGColor",
+			RedComponent:              colorArgs[0].value.(float64),
+			GreenComponent:            colorArgs[1].value.(float64),
+			BlueComponent:             colorArgs[2].value.(float64),
+			AlphaComponent:            colorArgs[3].value,
 		}
 	case Quantity:
 		return makeQuantityFieldValue(arg.value.([]actionArgument))
@@ -675,9 +687,9 @@ const (
 )
 
 // makeDictionary creates a Shortcut dictionary value.
-func makeDictionary(value interface{}) (dictItems []map[string]any) {
+func makeDictionary(value interface{}) (dictItems []WFDictionaryFieldValueItem) {
 	if value == nil {
-		return []map[string]any{}
+		return []WFDictionaryFieldValueItem{}
 	}
 	for key, item := range value.(map[string]interface{}) {
 		dictItems = append(dictItems, makeDictionaryItem(key, item))
@@ -686,7 +698,7 @@ func makeDictionary(value interface{}) (dictItems []map[string]any) {
 }
 
 // makeDictionaryItem creates an inner dictionary value.
-func makeDictionaryItem(key string, value any) map[string]any {
+func makeDictionaryItem(key string, value any) WFDictionaryFieldValueItem {
 	if value == nil {
 		value = ""
 	}
@@ -726,7 +738,7 @@ func makeDictionaryItem(key string, value any) map[string]any {
 		case reflect.Slice:
 			itemType = itemTypeArray
 			serializedType = "WFArrayParameterState"
-			var arrayValue []map[string]interface{}
+			var arrayValue []WFDictionaryFieldValueItem
 			for _, item := range value.([]interface{}) {
 				arrayValue = append(arrayValue, makeDictionaryItem("", item))
 			}
@@ -762,14 +774,15 @@ func makeDictionaryItem(key string, value any) map[string]any {
 	return makeDictionaryItemValue(key, itemType, serializedType, wfValue)
 }
 
-func makeDictionaryItemValue(key string, itemType dictDataType, serializedType string, wfValue map[string]any) map[string]any {
+func makeDictionaryItemValue(key string, itemType dictDataType, serializedType string, wfValue map[string]any) WFDictionaryFieldValueItem {
 	var wfValueParams = map[string]any{
 		"WFSerializationType": serializedType,
 	}
 	maps.Copy(wfValueParams, wfValue)
-	var valueData = map[string]any{
-		"WFItemType": itemType,
-		"WFValue":    wfValueParams,
+
+	var item = WFDictionaryFieldValueItem{
+		WFItemType: int(itemType),
+		WFValue:    wfValueParams,
 	}
 
 	if key != "" {
@@ -795,10 +808,10 @@ func makeDictionaryItemValue(key string, itemType dictDataType, serializedType s
 			"WFSerializationType": "WFTextTokenString",
 		}
 		maps.Copy(wfKeyParams, wfKey)
-		valueData["WFKey"] = wfKeyParams
+		item.WFKey = wfKeyParams
 	}
 
-	return valueData
+	return item
 }
 
 func makeOutputName(token *token) string {
@@ -883,11 +896,11 @@ func makeConditionalAction(t *token) {
 			}
 			if len(firstCondition.arguments) > 1 {
 				var secondArg = firstCondition.arguments[1]
-				conditionalParameter("", conditionalParams, &secondArg.valueType, secondArg.value)
+				conditionalParameterLegacy("", conditionalParams, &secondArg.valueType, secondArg.value)
 			}
 			if len(firstCondition.arguments) > 2 {
 				var thirdArg = firstCondition.arguments[2]
-				conditionalParameter("WFAnotherNumber", conditionalParams, &thirdArg.valueType, thirdArg.value)
+				conditionalParameterLegacy("WFAnotherNumber", conditionalParams, &thirdArg.valueType, thirdArg.value)
 			}
 			conditionalParams["WFCondition"] = firstCondition.condition
 			conditionalParams["WFControlFlowMode"] = startStatement
@@ -905,41 +918,103 @@ func makeConditionalAction(t *token) {
 	addStdAction("conditional", &conditionalParams)
 }
 
-var filterTemplates []map[string]any
+var filterTemplates []WFConditionParam
 
-func makeConditions(wfConditions *WFConditions) map[string]any {
-	filterTemplates = []map[string]any{}
+func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate {
+	filterTemplates = []WFConditionParam{}
 	for _, condition := range wfConditions.conditions {
-		var conditionParams = map[string]any{
-			"WFCondition": condition.condition,
-			"WFInput": map[string]any{
-				"Type":     "Variable",
-				"Variable": variableValue(condition.arguments[0].value.(varValue)),
+		var conditionParam = WFConditionParam{
+			WFCondition: condition.condition,
+			WFInput: WFInputVariable{
+				Type:     "Variable",
+				Variable: variableValue(condition.arguments[0].value.(varValue)),
 			},
 		}
 
 		if len(condition.arguments) > 1 {
 			var argumentTwo = condition.arguments[1]
-			conditionalParameter("", conditionParams, &argumentTwo.valueType, argumentTwo.value)
+			conditionalParameter("", &conditionParam, &argumentTwo.valueType, argumentTwo.value)
 		}
 		if len(condition.arguments) > 2 {
 			var argumentThree = condition.arguments[2]
-			conditionalParameter("WFAnotherNumber", conditionParams, &argumentThree.valueType, argumentThree.value)
+			conditionalParameter("WFAnotherNumber", &conditionParam, &argumentThree.valueType, argumentThree.value)
 		}
 
-		filterTemplates = append(filterTemplates, conditionParams)
+		filterTemplates = append(filterTemplates, conditionParam)
 	}
 
-	return map[string]any{
-		"Value": map[string]any{
-			"WFActionParameterFilterPrefix":    wfConditions.WFActionParameterFilterPrefix,
-			"WFActionParameterFilterTemplates": filterTemplates,
+	return WFContentPredicateTableTemplate{
+		Value: WFConditionValue{
+			WFActionParameterFilterPrefix:    wfConditions.WFActionParameterFilterPrefix,
+			WFActionParameterFilterTemplates: filterTemplates,
 		},
-		"WFSerializationType": "WFContentPredicateTableTemplate",
+		WFSerializationType: "WFContentPredicateTableTemplate",
 	}
 }
 
-func conditionalParameter(key string, conditionalParams map[string]any, typeOf *tokenType, value any) {
+func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *tokenType, value any) {
+	switch *typeOf {
+	case String:
+		paramVal := paramValue(actionArgument{
+			valueType: *typeOf,
+			value:     value,
+		}, String)
+		if key == "WFAnotherNumber" {
+			conditionParam.WFAnotherNumber = paramVal
+		} else {
+			conditionParam.WFConditionalActionString = paramVal
+		}
+	case Integer:
+		paramVal := paramValue(actionArgument{
+			valueType: *typeOf,
+			value:     value,
+		}, String)
+		if key == "WFAnotherNumber" {
+			conditionParam.WFAnotherNumber = paramVal
+		} else {
+			conditionParam.WFNumberValue = paramVal
+		}
+	case Bool:
+		var boolNumber = "0"
+		if value == true {
+			boolNumber = "1"
+		}
+		paramVal := paramValue(actionArgument{
+			valueType: Integer,
+			value:     boolNumber,
+		}, Integer)
+		if key == "WFAnotherNumber" {
+			conditionParam.WFAnotherNumber = paramVal
+		} else {
+			conditionParam.WFNumberValue = paramVal
+		}
+	case Variable:
+		conditionalParameterVariable(conditionParam, key, value)
+	}
+}
+
+func conditionalParameterVariable(conditionParam *WFConditionParam, key string, value any) {
+	var condVarValue = value.(varValue)
+	var variable = variables[condVarValue.value.(string)]
+	switch variable.valueType {
+	case Integer:
+		if key == "WFAnotherNumber" {
+			conditionParam.WFAnotherNumber = variableValue(condVarValue)
+		} else {
+			conditionParam.WFNumberValue = variableValue(condVarValue)
+		}
+	default:
+		paramVal := attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
+		if key == "WFAnotherNumber" {
+			conditionParam.WFAnotherNumber = paramVal
+		} else {
+			conditionParam.WFConditionalActionString = paramVal
+		}
+	}
+}
+
+// conditionalParameterLegacy is for iOS < 18 compatibility where we still use map[string]any
+func conditionalParameterLegacy(key string, conditionalParams map[string]any, typeOf *tokenType, value any) {
 	if key == "" {
 		if *typeOf == String {
 			key = "WFConditionalActionString"
@@ -968,11 +1043,11 @@ func conditionalParameter(key string, conditionalParams map[string]any, typeOf *
 			value:     boolNumber,
 		}, Integer)
 	case Variable:
-		conditionalParameterVariable(conditionalParams, value)
+		conditionalParameterVariableLegacy(conditionalParams, value)
 	}
 }
 
-func conditionalParameterVariable(conditionalParams map[string]any, value any) {
+func conditionalParameterVariableLegacy(conditionalParams map[string]any, value any) {
 	var condVarValue = value.(varValue)
 	var variable = variables[condVarValue.value.(string)]
 	switch variable.valueType {
@@ -1077,11 +1152,11 @@ func makeRepeatEachAction(t *token) {
 }
 
 type WFQuestion struct {
-	ParameterKey string
-	Category     string
-	ActionIndex  int
-	Text         string
-	DefaultValue any
+	ParameterKey string `plist:",omitempty"`
+	Category     string `plist:",omitempty"`
+	ActionIndex  int    `plist:",omitempty"`
+	Text         string `plist:",omitempty"`
+	DefaultValue any    `plist:",omitempty"`
 }
 
 func generateImportQuestions() (importQuestions []WFQuestion) {


### PR DESCRIPTION
This gives us type safety and makes it easier to use, with properties being on the struct rather than adding to a map. This should be much cleaner Shortcut generation and will now omit param keys that are empty to prevent properties that are not being used from confusing the Shortcuts app, and making smaller Shortcuts overall.