### PR TITLE
Fix & improve conditionals

### DIFF
--- a/action.go
+++ b/action.go
@@ -1069,9 +1069,6 @@ func makeActionValue(identifier string, arguments []actionArgument) action {
 }
 
 func makeQuantityFieldValue(args []actionArgument) WFQuantityFieldValue {
-	// Use paramValue with each arg's own valueType so this function is safe to
-	// call outside an action context (e.g. from conditional parameter handling),
-	// where currentAction.definition.parameters may be empty.
 	var magnitude any
 	if args[0].valueType == Variable {
 		magnitude = variableValueWithSerialization(args[0].value.(varValue), "")

--- a/action.go
+++ b/action.go
@@ -1079,7 +1079,7 @@ func makeQuantityFieldValue(args []actionArgument) WFQuantityFieldValue {
 	if args[0].valueType == Variable {
 		magnitude = variableValueWithSerialization(args[0].value.(varValue), "")
 	} else {
-		magnitude = paramValue(args[0], args[0].valueType)
+		magnitude = fmt.Sprintf("%v", paramValue(args[0], args[0].valueType))
 	}
 
 	return WFQuantityFieldValue{

--- a/action.go
+++ b/action.go
@@ -1069,17 +1069,20 @@ func makeActionValue(identifier string, arguments []actionArgument) action {
 }
 
 func makeQuantityFieldValue(args []actionArgument) WFQuantityFieldValue {
+	// Use paramValue with each arg's own valueType so this function is safe to
+	// call outside an action context (e.g. from conditional parameter handling),
+	// where currentAction.definition.parameters may be empty.
 	var magnitude any
 	if args[0].valueType == Variable {
 		magnitude = variableValueWithSerialization(args[0].value.(varValue), "")
 	} else {
-		magnitude = argumentValue(args, 0)
+		magnitude = paramValue(args[0], args[0].valueType)
 	}
 
 	return WFQuantityFieldValue{
 		Value: WFQuantityValue{
 			Magnitude: magnitude,
-			Unit:      argumentValue(args, 1),
+			Unit:      paramValue(args[1], args[1].valueType),
 		},
 		WFSerializationType: "WFQuantityFieldValue",
 	}

--- a/action.go
+++ b/action.go
@@ -429,6 +429,9 @@ func typeCheck(param *parameterDefinition, argument *actionArgument) {
 			return
 		}
 		if argValueType != param.validType && param.validType != Variable && getVar.variableType != Ask {
+			if argValueType == Date && param.validType == String {
+				return
+			}
 			parserError(fmt.Sprintf("Invalid variable value %v (%s) for argument '%s' (%s).\n%s",
 				argVal,
 				argValueType,
@@ -463,6 +466,9 @@ func validActionOutput(param *parameterDefinition, value any) {
 			return
 		}
 		if actionOutputType != param.validType && param.validType != Variable {
+			if actionOutputType == Date && param.validType == String {
+				return
+			}
 			parserError(fmt.Sprintf("Invalid variable value of action '%v' (%s) for argument '%s' (%s).\n%s",
 				actionIdent+"()",
 				actionOutputType,

--- a/actions/calendar.cherri
+++ b/actions/calendar.cherri
@@ -102,7 +102,7 @@ enum dateUnit {
 }
 
 // [Doc]: [Dates] Adjust Date: Adjust a date or get the start of a time period.
-action adjustDate(text date: 'WFDate', dateAdjustOperation operation: 'WFAdjustOperation', #dateUnit ?unit: 'WFDuration'): date
+action adjustDate(date date: 'WFDate', dateAdjustOperation operation: 'WFAdjustOperation', #dateUnit ?unit: 'WFDuration'): date
 
 enum holidayYear {
     '2023',
@@ -187,18 +187,18 @@ enum timeFormats {
 }
 
 // [Doc]: [Formatting] Format Date: Format a date using a standard or custom format.
-action default 'format.date' formatDate(text date: 'WFDate', dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short", text ?customDateFormat: 'WFDateFormat'): text {
+action default 'format.date' formatDate(date date: 'WFDate', dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short", text ?customDateFormat: 'WFDateFormat'): text {
 	"WFTimeFormatStyle": "None"
 }
 
 // [Doc]: [Formatting] Format Time: Format a time using a standard or custom format.
-action 'format.date' formatTime(text time: 'WFDate', timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short"): text {
+action 'format.date' formatTime(date time: 'WFDate', timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short"): text {
 	"WFDateFormatStyle": "None"
 }
 
 // [Doc]: [Formatting] Format Timestamp: Format a timestamp using standard formats and/or a custom date format.
 action 'format.date' formatTimestamp(
-    text date: 'WFDate',
+    date date: 'WFDate',
     dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short",
     timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short",
     text ?customDateFormat: 'WFDateFormat'

--- a/actions/calendar.cherri
+++ b/actions/calendar.cherri
@@ -187,12 +187,12 @@ enum timeFormats {
 }
 
 // [Doc]: [Formatting] Format Date: Format a date using a standard or custom format.
-action default 'format.date' formatDate(text date: 'WFDate', dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short", text ?customDateFormat: 'WFDateFormat') {
+action default 'format.date' formatDate(text date: 'WFDate', dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short", text ?customDateFormat: 'WFDateFormat'): text {
 	"WFTimeFormatStyle": "None"
 }
 
 // [Doc]: [Formatting] Format Time: Format a time using a standard or custom format.
-action 'format.date' formatTime(text time: 'WFDate', timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short") {
+action 'format.date' formatTime(text time: 'WFDate', timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short"): text {
 	"WFDateFormatStyle": "None"
 }
 
@@ -202,4 +202,4 @@ action 'format.date' formatTimestamp(
     dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short",
     timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short",
     text ?customDateFormat: 'WFDateFormat'
-)
+): text

--- a/actions/calendar.cherri
+++ b/actions/calendar.cherri
@@ -76,7 +76,7 @@ action 'timer.start' startTimer(#timeDuration duration: 'WFDuration' = qty(0, "m
 action 'detect.date' getDates(variable input: 'WFInput'): array
 
 // [Doc]: [Dates] Date: Create a date value from `date`. Example: October 5, 2022.
-action date(text date: 'WFDateActionDate') {
+action date(text date: 'WFDateActionDate'): date {
 	"WFDateActionMode": "Specified Date"
 }
 
@@ -102,7 +102,7 @@ enum dateUnit {
 }
 
 // [Doc]: [Dates] Adjust Date: Adjust a date or get the start of a time period.
-action adjustDate(text date: 'WFDate', dateAdjustOperation operation: 'WFAdjustOperation', #dateUnit ?unit: 'WFDuration')
+action adjustDate(text date: 'WFDate', dateAdjustOperation operation: 'WFAdjustOperation', #dateUnit ?unit: 'WFDuration'): date
 
 enum holidayYear {
     '2023',
@@ -160,10 +160,10 @@ enum holiday {
 }
 
 // [Doc]: [Dates] Get Holiday Date: Get the date of a holiday, optionally specifically for a few past or future years.
-action 'date' getHolidayDate(holiday holiday: 'WFDateActionMode', eventOccurrenceMode ?occurrenceMode: 'WFEventOccurrenceMode' = "Next Occurrence", holidayYear ?forYear: 'WFEventOccurrenceSpecifiedYear'): text
+action 'date' getHolidayDate(holiday holiday: 'WFDateActionMode', eventOccurrenceMode ?occurrenceMode: 'WFEventOccurrenceMode' = "Next Occurrence", holidayYear ?forYear: 'WFEventOccurrenceSpecifiedYear'): date
 
 // [Doc]: [Dates] Current Date: Get the current date.
-action default 'date' currentDate() {
+action default 'date' currentDate(): date {
     "WFDateActionMode": "Current Date"
 }
 

--- a/actions/calendar.cherri
+++ b/actions/calendar.cherri
@@ -102,7 +102,7 @@ enum dateUnit {
 }
 
 // [Doc]: [Dates] Adjust Date: Adjust a date or get the start of a time period.
-action adjustDate(date date: 'WFDate', dateAdjustOperation operation: 'WFAdjustOperation', #dateUnit ?unit: 'WFDuration'): date
+action adjustDate(text date: 'WFDate', dateAdjustOperation operation: 'WFAdjustOperation', #dateUnit ?unit: 'WFDuration'): date
 
 enum holidayYear {
     '2023',
@@ -187,18 +187,18 @@ enum timeFormats {
 }
 
 // [Doc]: [Formatting] Format Date: Format a date using a standard or custom format.
-action default 'format.date' formatDate(date date: 'WFDate', dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short", text ?customDateFormat: 'WFDateFormat'): text {
+action default 'format.date' formatDate(text date: 'WFDate', dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short", text ?customDateFormat: 'WFDateFormat'): text {
 	"WFTimeFormatStyle": "None"
 }
 
 // [Doc]: [Formatting] Format Time: Format a time using a standard or custom format.
-action 'format.date' formatTime(date time: 'WFDate', timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short"): text {
+action 'format.date' formatTime(text time: 'WFDate', timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short"): text {
 	"WFDateFormatStyle": "None"
 }
 
 // [Doc]: [Formatting] Format Timestamp: Format a timestamp using standard formats and/or a custom date format.
 action 'format.date' formatTimestamp(
-    date date: 'WFDate',
+    text date: 'WFDate',
     dateFormats ?dateFormat: 'WFDateFormatStyle' = "Short",
     timeFormats ?timeFormat: 'WFTimeFormatStyle' = "Short",
     text ?customDateFormat: 'WFDateFormat'

--- a/parser.go
+++ b/parser.go
@@ -906,8 +906,10 @@ func collectType(valueType *tokenType, value *any, until rune) {
 		*valueType = Variable
 	case tokenAhead(Color):
 		*valueType = Color
+	case tokenAhead(Date):
+		*valueType = Date
 	default:
-		parserError(fmt.Sprintf("Unknown type '%s'\n\nAvailable types: \n- text\n- rawtext\n- number\n- float\n- bool\n- array\n- dictionary\n- variable\n- color", collectUntil(until)))
+		parserError(fmt.Sprintf("Unknown type '%s'\n\nAvailable types: \n- text\n- rawtext\n- number\n- float\n- bool\n- array\n- dictionary\n- variable\n- color\n- date", collectUntil(until)))
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -1315,8 +1315,6 @@ func collectConditional() (conditional condition) {
 
 		skipWhitespace()
 
-		// Zero-argument conditions (e.g. isToday) have no comparison value;
-		// the next char will be the block opener or a logical operator.
 		if char == '{' || char == '&' || char == '|' {
 			return
 		}

--- a/parser.go
+++ b/parser.go
@@ -1315,6 +1315,12 @@ func collectConditional() (conditional condition) {
 
 		skipWhitespace()
 
+		// Zero-argument conditions (e.g. isToday) have no comparison value;
+		// the next char will be the block opener or a logical operator.
+		if char == '{' || char == '&' || char == '|' {
+			return
+		}
+
 		var variableTwoType tokenType
 		var variableTwoValue any
 		collectValue(&variableTwoType, &variableTwoValue, ' ')

--- a/parser.go
+++ b/parser.go
@@ -1353,6 +1353,11 @@ func checkConditionalTypes(conditional *tokenType, variableType tokenType, value
 		if found && variableValue.valueType != Variable {
 			variableType = variableValue.valueType
 		}
+		if variableType == Action {
+			if a, ok := variableValue.value.(action); ok && a.def != nil {
+				variableType = a.def.outputType
+			}
+		}
 		if variable.coerce != "" {
 			variableType = tokenType(variable.coerce)
 		}

--- a/shortcut.go
+++ b/shortcut.go
@@ -154,6 +154,9 @@ type WFConditionParam struct {
 	WFConditionalActionString any             `plist:",omitempty"`
 	WFNumberValue             any             `plist:",omitempty"`
 	WFAnotherNumber           any             `plist:",omitempty"`
+	WFDate                    any             `plist:",omitempty"`
+	WFAnotherDate             any             `plist:",omitempty"`
+	WFDuration                any             `plist:",omitempty"`
 }
 
 type WFInputVariable struct {
@@ -346,6 +349,7 @@ var conditions = map[tokenType]int{
 	LessThan:       0,
 	LessOrEqual:    1,
 	Between:        1003,
+	IsToday:        1002,
 }
 
 var conditionFilterPrefixes = map[tokenType]int{
@@ -354,19 +358,20 @@ var conditionFilterPrefixes = map[tokenType]int{
 }
 
 var allowedConditionalTypes = map[tokenType][]tokenType{
-	Is:             {String, Integer, Bool, Action},
-	Not:            {String, Integer, Bool, Action},
+	Is:             {String, Integer, Bool, Action, Date},
+	Not:            {String, Integer, Bool, Action, Date},
 	Any:            {},
 	Empty:          {},
 	Contains:       {String, Arr},
 	DoesNotContain: {String, Arr},
 	BeginsWith:     {String},
 	EndsWith:       {String},
-	GreaterThan:    {Integer, Float},
-	GreaterOrEqual: {Integer, Float},
-	LessThan:       {Integer, Float},
-	LessOrEqual:    {Integer, Float},
-	Between:        {Integer, Float},
+	GreaterThan:    {Integer, Float, Quantity, Date},
+	GreaterOrEqual: {Integer, Float, Date},
+	LessThan:       {Integer, Float, Quantity, Date},
+	LessOrEqual:    {Integer, Float, Date},
+	Between:        {Integer, Float, Date},
+	IsToday:        {},
 }
 
 /* Menus */

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -850,8 +850,6 @@ func makeConditionalAction(t *token) {
 				"Type":     "Variable",
 				"Variable": variableValue(firstArg.value.(varValue)),
 			}
-			// Apply the same duration-aware remap as the modern path: Shortcuts
-			// uses 1000/1001 for date-relative qty comparisons, not 2/0.
 			var conditionCode = firstCondition.condition
 			if len(firstCondition.arguments) > 1 && firstCondition.arguments[1].valueType == Quantity {
 				switch conditionCode {
@@ -861,11 +859,12 @@ func makeConditionalAction(t *token) {
 					conditionCode = 1001
 				}
 			}
+			var inputType = inputEffectiveType(firstArg.value.(varValue))
 			if len(firstCondition.arguments) > 1 {
-				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[1])
+				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[1], inputType)
 			}
 			if len(firstCondition.arguments) > 2 {
-				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[2])
+				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[2], inputType)
 			}
 			conditionalParams["WFCondition"] = conditionCode
 			conditionalParams["WFControlFlowMode"] = startStatement
@@ -885,12 +884,65 @@ func makeConditionalAction(t *token) {
 
 var filterTemplates []WFConditionParam
 
+// inputEffectiveType resolves a conditional's left-hand variable to its concrete type,
+// which determines which plist key the comparison value is written into.
+func inputEffectiveType(v varValue) tokenType {
+	var identifier = v.value.(string)
+	if global, found := globals[identifier]; found {
+		return global.valueType
+	}
+	if variable, found := variables[identifier]; found {
+		if variable.valueType == Action {
+			if a, ok := variable.value.(action); ok && a.def != nil {
+				return a.def.outputType
+			}
+		}
+		return variable.valueType
+	}
+	return String
+}
+
+func routeConditionalValue(param *WFConditionParam, val any, inputType tokenType) {
+	switch inputType {
+	case Date:
+		if param.WFDate == nil {
+			param.WFDate = val
+		} else {
+			param.WFAnotherDate = val
+		}
+	case Integer, Float:
+		if param.WFNumberValue == nil {
+			param.WFNumberValue = val
+		} else {
+			param.WFAnotherNumber = val
+		}
+	default:
+		param.WFConditionalActionString = val
+	}
+}
+
+func routeConditionalValueLegacy(params map[string]any, val any, inputType tokenType) {
+	switch inputType {
+	case Date:
+		if _, exists := params["WFDate"]; !exists {
+			params["WFDate"] = val
+		} else {
+			params["WFAnotherDate"] = val
+		}
+	case Integer, Float:
+		if _, exists := params["WFNumberValue"]; !exists {
+			params["WFNumberValue"] = val
+		} else {
+			params["WFAnotherNumber"] = val
+		}
+	default:
+		params["WFConditionalActionString"] = val
+	}
+}
+
 func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate {
 	filterTemplates = []WFConditionParam{}
 	for _, condition := range wfConditions.conditions {
-		// Shortcuts uses 1000 ("is more than N time before now") and 1001
-		// ("is within N time of now") when comparing dates by duration. The
-		// generic GreaterThan (2) and LessThan (0) codes only apply to numbers.
 		var conditionCode = condition.condition
 		if len(condition.arguments) > 1 && condition.arguments[1].valueType == Quantity {
 			switch conditionCode {
@@ -901,6 +953,7 @@ func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate 
 			}
 		}
 
+		var inputType = inputEffectiveType(condition.arguments[0].value.(varValue))
 		var conditionParam = WFConditionParam{
 			WFCondition: conditionCode,
 			WFInput: WFInputVariable{
@@ -910,10 +963,10 @@ func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate 
 		}
 
 		if len(condition.arguments) > 1 {
-			conditionalParameter(&conditionParam, condition.arguments[1])
+			conditionalParameter(&conditionParam, condition.arguments[1], inputType)
 		}
 		if len(condition.arguments) > 2 {
-			conditionalParameter(&conditionParam, condition.arguments[2])
+			conditionalParameter(&conditionParam, condition.arguments[2], inputType)
 		}
 
 		filterTemplates = append(filterTemplates, conditionParam)
@@ -928,137 +981,47 @@ func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate 
 	}
 }
 
-func conditionalParameter(param *WFConditionParam, arg actionArgument) {
+func conditionalParameter(param *WFConditionParam, arg actionArgument, inputType tokenType) {
 	switch arg.valueType {
-	case String:
-		param.WFConditionalActionString = paramValue(arg, String)
-	case Integer, Float:
-		var val = paramValue(arg, Integer)
-		if param.WFNumberValue == nil {
-			param.WFNumberValue = val
-		} else {
-			param.WFAnotherNumber = val
-		}
-	case Bool:
-		var boolNumber = 0
-		if arg.value == true {
-			boolNumber = 1
-		}
-		var val = paramValue(actionArgument{valueType: Integer, value: boolNumber}, Integer)
-		if param.WFNumberValue == nil {
-			param.WFNumberValue = val
-		} else {
-			param.WFAnotherNumber = val
-		}
-	case Date:
-		var val = paramValue(arg, String)
-		if param.WFDate == nil {
-			param.WFDate = val
-		} else {
-			param.WFAnotherDate = val
-		}
 	case Quantity:
 		param.WFDuration = makeQuantityFieldValue(arg.value.([]actionArgument))
 	case Variable:
-		conditionalParameterVariable(param, arg)
-	}
-}
-
-func conditionalParameterVariable(param *WFConditionParam, arg actionArgument) {
-	var condVarValue = arg.value.(varValue)
-	var variable = variables[condVarValue.value.(string)]
-	var val = variableValue(condVarValue)
-	// When a variable was assigned from an action, resolve the action's declared
-	// output type so the comparison value routes to the right plist key.
-	var effectiveType = variable.valueType
-	if effectiveType == Action {
-		if a, ok := variable.value.(action); ok && a.def != nil {
-			effectiveType = a.def.outputType
-		}
-	}
-	switch effectiveType {
-	case Integer, Float:
-		if param.WFNumberValue == nil {
-			param.WFNumberValue = val
-		} else {
-			param.WFAnotherNumber = val
-		}
-	case Date:
-		if param.WFDate == nil {
-			param.WFDate = val
-		} else {
-			param.WFAnotherDate = val
-		}
-	default:
-		param.WFConditionalActionString = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
-	}
-}
-
-// conditionalParameterLegacy is for iOS < 18 compatibility where we still use map[string]any
-func conditionalParameterLegacy(params map[string]any, arg actionArgument) {
-	switch arg.valueType {
-	case String:
-		params["WFConditionalActionString"] = paramValue(arg, String)
-	case Integer, Float:
-		var val = paramValue(arg, Integer)
-		if _, exists := params["WFNumberValue"]; !exists {
-			params["WFNumberValue"] = val
-		} else {
-			params["WFAnotherNumber"] = val
-		}
+		conditionalParameterVariable(param, arg, inputType)
 	case Bool:
 		var boolNumber = 0
 		if arg.value == true {
 			boolNumber = 1
 		}
-		var val = paramValue(actionArgument{valueType: Integer, value: boolNumber}, Integer)
-		if _, exists := params["WFNumberValue"]; !exists {
-			params["WFNumberValue"] = val
-		} else {
-			params["WFAnotherNumber"] = val
-		}
-	case Date:
-		var val = paramValue(arg, String)
-		if _, exists := params["WFDate"]; !exists {
-			params["WFDate"] = val
-		} else {
-			params["WFAnotherDate"] = val
-		}
-	case Quantity:
-		params["WFDuration"] = makeQuantityFieldValue(arg.value.([]actionArgument))
-	case Variable:
-		conditionalParameterVariableLegacy(params, arg)
+		routeConditionalValue(param, paramValue(actionArgument{valueType: Integer, value: boolNumber}, Integer), inputType)
+	default:
+		routeConditionalValue(param, paramValue(arg, arg.valueType), inputType)
 	}
 }
 
-func conditionalParameterVariableLegacy(params map[string]any, arg actionArgument) {
-	var condVarValue = arg.value.(varValue)
-	var variable = variables[condVarValue.value.(string)]
-	var val = variableValue(condVarValue)
-	// When a variable was assigned from an action, resolve the action's declared
-	// output type so the comparison value routes to the right plist key.
-	var effectiveType = variable.valueType
-	if effectiveType == Action {
-		if a, ok := variable.value.(action); ok && a.def != nil {
-			effectiveType = a.def.outputType
+func conditionalParameterVariable(param *WFConditionParam, arg actionArgument, inputType tokenType) {
+	routeConditionalValue(param, variableValue(arg.value.(varValue)), inputType)
+}
+
+// conditionalParameterLegacy is for iOS < 18 compatibility where we still use map[string]any
+func conditionalParameterLegacy(params map[string]any, arg actionArgument, inputType tokenType) {
+	switch arg.valueType {
+	case Quantity:
+		params["WFDuration"] = makeQuantityFieldValue(arg.value.([]actionArgument))
+	case Variable:
+		conditionalParameterVariableLegacy(params, arg, inputType)
+	case Bool:
+		var boolNumber = 0
+		if arg.value == true {
+			boolNumber = 1
 		}
-	}
-	switch effectiveType {
-	case Integer, Float:
-		if _, exists := params["WFNumberValue"]; !exists {
-			params["WFNumberValue"] = val
-		} else {
-			params["WFAnotherNumber"] = val
-		}
-	case Date:
-		if _, exists := params["WFDate"]; !exists {
-			params["WFDate"] = val
-		} else {
-			params["WFAnotherDate"] = val
-		}
+		routeConditionalValueLegacy(params, paramValue(actionArgument{valueType: Integer, value: boolNumber}, Integer), inputType)
 	default:
-		params["WFConditionalActionString"] = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
+		routeConditionalValueLegacy(params, paramValue(arg, arg.valueType), inputType)
 	}
+}
+
+func conditionalParameterVariableLegacy(params map[string]any, arg actionArgument, inputType tokenType) {
+	routeConditionalValueLegacy(params, variableValue(arg.value.(varValue)), inputType)
 }
 
 func makeMenuAction(t *token) {

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -850,13 +850,24 @@ func makeConditionalAction(t *token) {
 				"Type":     "Variable",
 				"Variable": variableValue(firstArg.value.(varValue)),
 			}
+			// Apply the same duration-aware remap as the modern path: Shortcuts
+			// uses 1000/1001 for date-relative qty comparisons, not 2/0.
+			var conditionCode = firstCondition.condition
+			if len(firstCondition.arguments) > 1 && firstCondition.arguments[1].valueType == Quantity {
+				switch conditionCode {
+				case conditions[GreaterThan]:
+					conditionCode = 1000
+				case conditions[LessThan]:
+					conditionCode = 1001
+				}
+			}
 			if len(firstCondition.arguments) > 1 {
 				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[1])
 			}
 			if len(firstCondition.arguments) > 2 {
 				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[2])
 			}
-			conditionalParams["WFCondition"] = firstCondition.condition
+			conditionalParams["WFCondition"] = conditionCode
 			conditionalParams["WFControlFlowMode"] = startStatement
 		} else {
 			var cond = t.value.(WFConditions)
@@ -877,8 +888,21 @@ var filterTemplates []WFConditionParam
 func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate {
 	filterTemplates = []WFConditionParam{}
 	for _, condition := range wfConditions.conditions {
+		// Shortcuts uses 1000 ("is more than N time before now") and 1001
+		// ("is within N time of now") when comparing dates by duration. The
+		// generic GreaterThan (2) and LessThan (0) codes only apply to numbers.
+		var conditionCode = condition.condition
+		if len(condition.arguments) > 1 && condition.arguments[1].valueType == Quantity {
+			switch conditionCode {
+			case conditions[GreaterThan]:
+				conditionCode = 1000
+			case conditions[LessThan]:
+				conditionCode = 1001
+			}
+		}
+
 		var conditionParam = WFConditionParam{
-			WFCondition: condition.condition,
+			WFCondition: conditionCode,
 			WFInput: WFInputVariable{
 				Type:     "Variable",
 				Variable: variableValue(condition.arguments[0].value.(varValue)).(WFTextTokenAttachment),
@@ -944,7 +968,15 @@ func conditionalParameterVariable(param *WFConditionParam, arg actionArgument) {
 	var condVarValue = arg.value.(varValue)
 	var variable = variables[condVarValue.value.(string)]
 	var val = variableValue(condVarValue)
-	switch variable.valueType {
+	// When a variable was assigned from an action, resolve the action's declared
+	// output type so the comparison value routes to the right plist key.
+	var effectiveType = variable.valueType
+	if effectiveType == Action {
+		if a, ok := variable.value.(action); ok && a.def != nil {
+			effectiveType = a.def.outputType
+		}
+	}
+	switch effectiveType {
 	case Integer, Float:
 		if param.WFNumberValue == nil {
 			param.WFNumberValue = val
@@ -1003,7 +1035,15 @@ func conditionalParameterVariableLegacy(params map[string]any, arg actionArgumen
 	var condVarValue = arg.value.(varValue)
 	var variable = variables[condVarValue.value.(string)]
 	var val = variableValue(condVarValue)
-	switch variable.valueType {
+	// When a variable was assigned from an action, resolve the action's declared
+	// output type so the comparison value routes to the right plist key.
+	var effectiveType = variable.valueType
+	if effectiveType == Action {
+		if a, ok := variable.value.(action); ok && a.def != nil {
+			effectiveType = a.def.outputType
+		}
+	}
+	switch effectiveType {
 	case Integer, Float:
 		if _, exists := params["WFNumberValue"]; !exists {
 			params["WFNumberValue"] = val

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -851,12 +851,10 @@ func makeConditionalAction(t *token) {
 				"Variable": variableValue(firstArg.value.(varValue)),
 			}
 			if len(firstCondition.arguments) > 1 {
-				var secondArg = firstCondition.arguments[1]
-				conditionalParameterLegacy("", conditionalParams, &secondArg.valueType, secondArg.value)
+				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[1])
 			}
 			if len(firstCondition.arguments) > 2 {
-				var thirdArg = firstCondition.arguments[2]
-				conditionalParameterLegacy("WFAnotherNumber", conditionalParams, &thirdArg.valueType, thirdArg.value)
+				conditionalParameterLegacy(conditionalParams, firstCondition.arguments[2])
 			}
 			conditionalParams["WFCondition"] = firstCondition.condition
 			conditionalParams["WFControlFlowMode"] = startStatement
@@ -965,47 +963,61 @@ func conditionalParameterVariable(param *WFConditionParam, arg actionArgument) {
 }
 
 // conditionalParameterLegacy is for iOS < 18 compatibility where we still use map[string]any
-func conditionalParameterLegacy(key string, conditionalParams map[string]any, typeOf *tokenType, value any) {
-	if key == "" {
-		if *typeOf == String {
-			key = "WFConditionalActionString"
-		} else if *typeOf == Integer || *typeOf == Bool {
-			key = "WFNumberValue"
-		}
-	}
-	switch *typeOf {
+func conditionalParameterLegacy(params map[string]any, arg actionArgument) {
+	switch arg.valueType {
 	case String:
-		conditionalParams[key] = paramValue(actionArgument{
-			valueType: *typeOf,
-			value:     value,
-		}, String)
-	case Integer:
-		conditionalParams[key] = paramValue(actionArgument{
-			valueType: *typeOf,
-			value:     value,
-		}, String)
+		params["WFConditionalActionString"] = paramValue(arg, String)
+	case Integer, Float:
+		var val = paramValue(arg, Integer)
+		if _, exists := params["WFNumberValue"]; !exists {
+			params["WFNumberValue"] = val
+		} else {
+			params["WFAnotherNumber"] = val
+		}
 	case Bool:
 		var boolNumber = 0
-		if value == true {
+		if arg.value == true {
 			boolNumber = 1
 		}
-		conditionalParams[key] = paramValue(actionArgument{
-			valueType: Integer,
-			value:     boolNumber,
-		}, Integer)
+		var val = paramValue(actionArgument{valueType: Integer, value: boolNumber}, Integer)
+		if _, exists := params["WFNumberValue"]; !exists {
+			params["WFNumberValue"] = val
+		} else {
+			params["WFAnotherNumber"] = val
+		}
+	case Date:
+		var val = paramValue(arg, String)
+		if _, exists := params["WFDate"]; !exists {
+			params["WFDate"] = val
+		} else {
+			params["WFAnotherDate"] = val
+		}
+	case Quantity:
+		params["WFDuration"] = makeQuantityFieldValue(arg.value.([]actionArgument))
 	case Variable:
-		conditionalParameterVariableLegacy(conditionalParams, value)
+		conditionalParameterVariableLegacy(params, arg)
 	}
 }
 
-func conditionalParameterVariableLegacy(conditionalParams map[string]any, value any) {
-	var condVarValue = value.(varValue)
+func conditionalParameterVariableLegacy(params map[string]any, arg actionArgument) {
+	var condVarValue = arg.value.(varValue)
 	var variable = variables[condVarValue.value.(string)]
+	var val = variableValue(condVarValue)
 	switch variable.valueType {
-	case Integer:
-		conditionalParams["WFNumberValue"] = variableValue(condVarValue)
+	case Integer, Float:
+		if _, exists := params["WFNumberValue"]; !exists {
+			params["WFNumberValue"] = val
+		} else {
+			params["WFAnotherNumber"] = val
+		}
+	case Date:
+		if _, exists := params["WFDate"]; !exists {
+			params["WFDate"] = val
+		} else {
+			params["WFAnotherDate"] = val
+		}
 	default:
-		conditionalParams["WFConditionalActionString"] = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
+		params["WFConditionalActionString"] = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
 	}
 }
 

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -888,12 +888,10 @@ func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate 
 		}
 
 		if len(condition.arguments) > 1 {
-			var argumentTwo = condition.arguments[1]
-			conditionalParameter("", &conditionParam, &argumentTwo.valueType, argumentTwo.value)
+			conditionalParameter(&conditionParam, condition.arguments[1])
 		}
 		if len(condition.arguments) > 2 {
-			var argumentThree = condition.arguments[2]
-			conditionalParameter("WFAnotherNumber", &conditionParam, &argumentThree.valueType, argumentThree.value)
+			conditionalParameter(&conditionParam, condition.arguments[2])
 		}
 
 		filterTemplates = append(filterTemplates, conditionParam)
@@ -908,60 +906,61 @@ func makeConditions(wfConditions *WFConditions) WFContentPredicateTableTemplate 
 	}
 }
 
-func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *tokenType, value any) {
-	switch *typeOf {
+func conditionalParameter(param *WFConditionParam, arg actionArgument) {
+	switch arg.valueType {
 	case String:
-		var paramVal = paramValue(actionArgument{
-			valueType: *typeOf,
-			value:     value,
-		}, String)
-		conditionStringValue(conditionParam, key, paramVal)
-	case Integer:
-		var paramVal = paramValue(actionArgument{
-			valueType: *typeOf,
-			value:     value,
-		}, Integer)
-		conditionIntegerValue(conditionParam, key, paramVal)
+		param.WFConditionalActionString = paramValue(arg, String)
+	case Integer, Float:
+		var val = paramValue(arg, Integer)
+		if param.WFNumberValue == nil {
+			param.WFNumberValue = val
+		} else {
+			param.WFAnotherNumber = val
+		}
 	case Bool:
 		var boolNumber = 0
-		if value == true {
+		if arg.value == true {
 			boolNumber = 1
 		}
-		var paramVal = paramValue(actionArgument{
-			valueType: Integer,
-			value:     boolNumber,
-		}, Integer)
-		conditionIntegerValue(conditionParam, key, paramVal)
+		var val = paramValue(actionArgument{valueType: Integer, value: boolNumber}, Integer)
+		if param.WFNumberValue == nil {
+			param.WFNumberValue = val
+		} else {
+			param.WFAnotherNumber = val
+		}
+	case Date:
+		var val = paramValue(arg, String)
+		if param.WFDate == nil {
+			param.WFDate = val
+		} else {
+			param.WFAnotherDate = val
+		}
+	case Quantity:
+		param.WFDuration = makeQuantityFieldValue(arg.value.([]actionArgument))
 	case Variable:
-		conditionalParameterVariable(conditionParam, key, value)
+		conditionalParameterVariable(param, arg)
 	}
 }
 
-func conditionalParameterVariable(conditionParam *WFConditionParam, key string, value any) {
-	var condVarValue = value.(varValue)
+func conditionalParameterVariable(param *WFConditionParam, arg actionArgument) {
+	var condVarValue = arg.value.(varValue)
 	var variable = variables[condVarValue.value.(string)]
+	var val = variableValue(condVarValue)
 	switch variable.valueType {
-	case Integer:
-		conditionIntegerValue(conditionParam, key, variableValue(condVarValue))
+	case Integer, Float:
+		if param.WFNumberValue == nil {
+			param.WFNumberValue = val
+		} else {
+			param.WFAnotherNumber = val
+		}
+	case Date:
+		if param.WFDate == nil {
+			param.WFDate = val
+		} else {
+			param.WFAnotherDate = val
+		}
 	default:
-		var paramVal = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
-		conditionStringValue(conditionParam, key, paramVal)
-	}
-}
-
-func conditionStringValue(param *WFConditionParam, key string, value any) {
-	if key == "WFAnotherNumber" {
-		param.WFAnotherNumber = value
-	} else {
-		param.WFConditionalActionString = value
-	}
-}
-
-func conditionIntegerValue(param *WFConditionParam, key string, value any) {
-	if key == "WFAnotherNumber" {
-		param.WFAnotherNumber = value
-	} else {
-		param.WFNumberValue = value
+		param.WFConditionalActionString = attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue)))
 	}
 }
 

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -910,7 +910,7 @@ func routeConditionalValue(param *WFConditionParam, val any, inputType tokenType
 		} else {
 			param.WFAnotherDate = val
 		}
-	case Integer, Float:
+	case Integer, Float, Bool:
 		if param.WFNumberValue == nil {
 			param.WFNumberValue = val
 		} else {
@@ -929,7 +929,7 @@ func routeConditionalValueLegacy(params map[string]any, val any, inputType token
 		} else {
 			params["WFAnotherDate"] = val
 		}
-	case Integer, Float:
+	case Integer, Float, Bool:
 		if _, exists := params["WFNumberValue"]; !exists {
 			params["WFNumberValue"] = val
 		} else {
@@ -999,7 +999,13 @@ func conditionalParameter(param *WFConditionParam, arg actionArgument, inputType
 }
 
 func conditionalParameterVariable(param *WFConditionParam, arg actionArgument, inputType tokenType) {
-	routeConditionalValue(param, variableValue(arg.value.(varValue)), inputType)
+	var condVarValue = arg.value.(varValue)
+	switch inputType {
+	case Date, Integer, Float, Bool:
+		routeConditionalValue(param, variableValue(condVarValue), inputType)
+	default:
+		routeConditionalValue(param, attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue))), inputType)
+	}
 }
 
 // conditionalParameterLegacy is for iOS < 18 compatibility where we still use map[string]any
@@ -1021,7 +1027,13 @@ func conditionalParameterLegacy(params map[string]any, arg actionArgument, input
 }
 
 func conditionalParameterVariableLegacy(params map[string]any, arg actionArgument, inputType tokenType) {
-	routeConditionalValueLegacy(params, variableValue(arg.value.(varValue)), inputType)
+	var condVarValue = arg.value.(varValue)
+	switch inputType {
+	case Date, Integer, Float, Bool:
+		routeConditionalValueLegacy(params, variableValue(condVarValue), inputType)
+	default:
+		routeConditionalValueLegacy(params, attachmentValues(fmt.Sprintf("{%s}", makeVariableReferenceString(condVarValue))), inputType)
+	}
 }
 
 func makeMenuAction(t *token) {

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -915,7 +915,7 @@ func conditionalParameter(key string, conditionParam *WFConditionParam, typeOf *
 			valueType: *typeOf,
 			value:     value,
 		}, String)
-		conditionIntegerValue(conditionParam, key, paramVal)
+		conditionStringValue(conditionParam, key, paramVal)
 	case Integer:
 		var paramVal = paramValue(actionArgument{
 			valueType: *typeOf,

--- a/tests/conditionals-date.cherri
+++ b/tests/conditionals-date.cherri
@@ -1,0 +1,3 @@
+@myDate = currentDate()
+
+if CurrentDate isToday {}

--- a/tests/conditionals-date.cherri
+++ b/tests/conditionals-date.cherri
@@ -1,3 +1,9 @@
 @myDate = currentDate()
+@myDate2 = date("April 30, 2026")
 
 if CurrentDate isToday {}
+if CurrentDate > qty(3, "hr") {} else {}
+if CurrentDate < qty(5, "min") {} else {}
+if CurrentDate == @myDate {}
+if CurrentDate > @myDate {}
+if CurrentDate <> @myDate @myDate2 {}

--- a/tests/date-comparisons.cherri
+++ b/tests/date-comparisons.cherri
@@ -1,0 +1,25 @@
+@today = currentDate()
+@formatted = formatDate(@today)
+@adjusted = adjustDate(@today, "Add", qty(5, "days"))
+@specifiedDate = date("April 16, 2026")
+
+// text input: comparison routes to WFConditionalActionString
+if @formatted == @today {} else {}
+
+// date input: comparison (text var) routes to WFDate
+if @adjusted < @formatted {} else {}
+
+// date input: comparison (date var) routes to WFDate
+if @adjusted == @today {} else {}
+if @adjusted > @today {} else {}
+
+// date input: between two dates routes to WFDate + WFAnotherDate
+if @adjusted <> @today @adjusted {} else {}
+
+// date input with holiday date
+@holiday = getHolidayDate("Christmas Day")
+if @holiday == @today {} else {}
+if @holiday > @adjusted {} else {}
+
+// date input: specified date comparison
+if @specifiedDate == @today {} else {}

--- a/token.go
+++ b/token.go
@@ -100,6 +100,7 @@ const (
 	LessThan       tokenType = "<"
 	LessOrEqual    tokenType = "<="
 	Between        tokenType = "<>"
+	IsToday        tokenType = "isToday"
 	Plus           tokenType = "+"
 	Minus          tokenType = "-"
 	Multiply       tokenType = "*"

--- a/variables.go
+++ b/variables.go
@@ -36,7 +36,7 @@ var globals = map[string]varValue{
 	},
 	"CurrentDate": {
 		variableType: "CurrentDate",
-		valueType:    String,
+		valueType:    Date,
 		value:        "CurrentDate",
 	},
 	"Clipboard": {


### PR DESCRIPTION
This fixes conditional string comparisons and refactors Shortcut conditional action generation to simplify it to properly support comparing different types.

In doing this, it was found that we don't support comparing date or time quantity values and their related conditional comparison types, and float values weren't supported either, even though they should likely be treated just as number values.

A refactor that's been needed to simplify conditionals and expand our support of comparison types and value types we can compare.