### PR TITLE
Emit WFWorkflow dict in run() codegen

### DIFF
--- a/actions/shortcuts.cherri
+++ b/actions/shortcuts.cherri
@@ -25,5 +25,3 @@ action v16.4 'com.apple.shortcuts.SearchShortcutsAction' searchShortcuts(text qu
 // [Doc]: Make Shortcut: Create a shortcut.
 action v16.4 'com.apple.shortcuts.CreateWorkflowAction' makeShortcut(text name, bool ?open: 'OpenWhenRun' = true)
 
-// [Doc]: Run Shortcut: Run Shortcut with name `shortcutName`, providing it with `input`.
-action 'runworkflow' run(text shortcutName: 'WFWorkflowName', variable input: 'WFInput')

--- a/actions_std.go
+++ b/actions_std.go
@@ -1125,6 +1125,42 @@ var actions = map[string]*actionDefinition{
 			return
 		},
 	},
+	"run": {
+		doc: selfDoc{
+			title:       "Run Shortcut",
+			description: "Run Shortcut with name `shortcutName`, providing it with `input`.",
+			category:    "shortcuts",
+		},
+		identifier: "runworkflow",
+		parameters: []parameterDefinition{
+			{
+				name:      "shortcutName",
+				key:       "WFWorkflowName",
+				validType: String,
+			},
+			{
+				name:      "input",
+				key:       "WFInput",
+				validType: Variable,
+				optional:  true,
+			},
+		},
+		// The runtime requires a WFWorkflow dict to bind the target shortcut;
+		// without it the action silently halts every subsequent action.
+		appendParamsFunc: func(args []actionArgument) map[string]any {
+			if len(args) == 0 {
+				return nil
+			}
+			var name = getArgValue(args[0]).(string)
+			return map[string]any{
+				"WFWorkflow": map[string]any{
+					"workflowIdentifier": uuid.New().String(),
+					"isSelf":             false,
+					"workflowName":       name,
+				},
+			}
+		},
+	},
 	"list": {
 		doc: selfDoc{
 			title:       "List",

--- a/cherri_test.go
+++ b/cherri_test.go
@@ -203,6 +203,48 @@ func TestActionIdentifiers(t *testing.T) {
 	resetParser()
 }
 
+func TestRunWorkflowEmitsWFWorkflowDict(t *testing.T) {
+	args.Args["no-ansi"] = ""
+	args.Args["skip-sign"] = ""
+	loadStandardActions()
+
+	currentTest = "tests/zz-run-workflow.cherri"
+	os.Args[1] = currentTest
+
+	compile()
+
+	var found bool
+	for _, a := range shortcut.WFWorkflowActions {
+		if a.WFWorkflowActionIdentifier != "is.workflow.actions.runworkflow" {
+			continue
+		}
+		found = true
+		var params = a.WFWorkflowActionParameters
+		var raw, ok = params["WFWorkflow"]
+		if !ok {
+			t.Fatal("runworkflow action missing WFWorkflow dict")
+		}
+		var workflow, isMap = raw.(map[string]any)
+		if !isMap {
+			t.Fatalf("WFWorkflow is not a map: %T", raw)
+		}
+		if name, _ := workflow["workflowName"].(string); name != "Other Shortcut" {
+			t.Errorf("workflowName: got %q, want %q", name, "Other Shortcut")
+		}
+		if isSelf, _ := workflow["isSelf"].(bool); isSelf {
+			t.Error("isSelf: got true, want false")
+		}
+		if _, hasID := workflow["workflowIdentifier"]; !hasID {
+			t.Error("workflowIdentifier missing")
+		}
+	}
+	if !found {
+		t.Fatal("no runworkflow action emitted")
+	}
+
+	resetParser()
+}
+
 func TestCapitalizeEmptyString(t *testing.T) {
 	if got := capitalize(""); got != "" {
 		t.Fatalf("expected empty string, got %q", got)

--- a/tests/zz-run-workflow.cherri
+++ b/tests/zz-run-workflow.cherri
@@ -1,0 +1,5 @@
+// compile-only: regression test for run() emitting the WFWorkflow dict
+
+@input = "hello"
+
+run("Other Shortcut", @input)


### PR DESCRIPTION
## Summary

The `runworkflow` action requires a structured `WFWorkflow` dict to bind the target shortcut. Without it the action silently halts every subsequent action in the workflow.

Cherri previously emitted only `WFInput` + `WFWorkflowName` from the DSL-defined `run` action. This PR moves `run` to a Go-side definition with an `appendParamsFunc` that injects the `WFWorkflow` dict at compile time, sourcing `workflowName` from the first argument.

## Changes

- `actions_std.go`: New `run` entry with `appendParamsFunc` emitting `{workflowIdentifier, workflowName, isSelf}`
- `actions/shortcuts.cherri`: Remove the now-redundant DSL definition for `run`
- `tests/zz-run-workflow.cherri`: New compile-only test input
- `cherri_test.go`: New `TestRunWorkflowEmitsWFWorkflowDict` asserting the dict appears in the output plist with the expected shape

## Test plan

- [x] `go test -run TestRunWorkflowEmitsWFWorkflowDict` passes
- [x] `go test -run TestCherriNoSign` passes (no regressions across 50+ test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)