### PR TITLE
Preserve rawAction identifier in output-capture forms

### DIFF
--- a/cherri_test.go
+++ b/cherri_test.go
@@ -203,6 +203,37 @@ func TestActionIdentifiers(t *testing.T) {
 	resetParser()
 }
 
+func TestRawActionOutputCapturePreservesIdentifier(t *testing.T) {
+	args.Args["no-ansi"] = ""
+	args.Args["skip-sign"] = ""
+	loadStandardActions()
+
+	currentTest = "tests/zz-raw-action-output.cherri"
+	os.Args[1] = currentTest
+
+	compile()
+
+	var wantIdentifiers = map[string]bool{
+		"com.alexhay.ToolboxProForShortcuts.GetAudioOutputsIntent": false,
+		"dk.simonbs.DataJar.SetValueIntent":                        false,
+	}
+	for _, a := range shortcut.WFWorkflowActions {
+		if _, ok := wantIdentifiers[a.WFWorkflowActionIdentifier]; ok {
+			wantIdentifiers[a.WFWorkflowActionIdentifier] = true
+		}
+		if a.WFWorkflowActionIdentifier == "is.workflow.actions.rawaction" {
+			t.Errorf("output-capture rawAction collapsed to is.workflow.actions.rawaction (lost bundle ID)")
+		}
+	}
+	for ident, found := range wantIdentifiers {
+		if !found {
+			t.Errorf("expected action with identifier %q, not emitted", ident)
+		}
+	}
+
+	resetParser()
+}
+
 func TestCapitalizeEmptyString(t *testing.T) {
 	if got := capitalize(""); got != "" {
 		t.Fatalf("expected empty string, got %q", got)

--- a/shortcutgen.go
+++ b/shortcutgen.go
@@ -203,6 +203,13 @@ func makeVariableValue(reference *WFActionReference, valueType tokenType, value 
 		var valuePtr = *value
 		var action = valuePtr.(action)
 		setCurrentAction(action.ident, actions[action.ident])
+		// Mirrors the rawAction identifier override in generateActions' bare
+		// case Action — without it, `@var = rawAction(id, ...)` and
+		// `const X = rawAction(id, ...)` lose the bundle ID and emit
+		// is.workflow.actions.rawaction instead.
+		if action.ident == "rawAction" && len(action.args) > 0 {
+			currentAction.definition.overrideIdentifier = getArgValue(action.args[0]).(string)
+		}
 		makeAction(action.args, reference)
 	case Dict:
 		addStdAction("dictionary", attachReferenceToParams(map[string]any{

--- a/tests/zz-raw-action-output.cherri
+++ b/tests/zz-raw-action-output.cherri
@@ -1,0 +1,10 @@
+// compile-only: regression test for output-capture rawAction preserving bundle ID
+
+const Outputs = rawAction("com.alexhay.ToolboxProForShortcuts.GetAudioOutputsIntent", {
+    "AppIntentDescriptor": ""
+})
+
+@picked = rawAction("dk.simonbs.DataJar.SetValueIntent", {
+    "key": "test",
+    "value": "hello"
+})


### PR DESCRIPTION
## Summary

The v2.2.0 fix at `generateActions`'s bare `case Action` mutates the shared `rawAction` definition's `overrideIdentifier` per-call, so the emitted plist gets the user-supplied bundle ID rather than collapsing to `is.workflow.actions.rawaction`.

But `@var = rawAction(id, ...)` and `const X = rawAction(id, ...)` emit `Variable` tokens with `valueType=Action`, which route through `makeVariableValue`'s `case Action` — a separate code path that called `setCurrentAction` + `makeAction` without the identifier override. So output-capture forms still collapsed.

This PR mirrors the identifier override into `makeVariableValue`'s `case Action`. Three-line fix; the comment cross-links the two call sites.

## Changes

- `shortcutgen.go`: Add identifier override to `makeVariableValue`'s `case Action`
- `tests/zz-raw-action-output.cherri`: New test exercising both `const X = rawAction(...)` and `@var = rawAction(...)` with custom bundle IDs
- `cherri_test.go`: New `TestRawActionOutputCapturePreservesIdentifier` asserting both bundle IDs appear in the output plist and no action collapses to `is.workflow.actions.rawaction`

## Test plan

- [x] `go test -run TestRawActionOutputCapturePreservesIdentifier` passes
- [x] Verified the test catches the bug by reverting the fix (FAIL with two collapse errors) and restoring (PASS)
- [x] `go test -run TestCherriNoSign` passes (no regressions across 50+ test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)