### PR TITLE
Fix empty custom separator decompile

### DIFF
--- a/actions_std.go
+++ b/actions_std.go
@@ -2055,14 +2055,16 @@ func decompTextParts(action *ShortcutAction) (arguments []string) {
 	arguments = append(arguments, decompValue(action.WFWorkflowActionParameters["text"]))
 
 	var glue string
+	var hasCustomSeparator bool
 	if action.WFWorkflowActionParameters["WFTextSeparator"] != nil {
 		glue = decompReferenceValue(action.WFWorkflowActionParameters["WFTextSeparator"])
 	}
 	if action.WFWorkflowActionParameters["WFTextCustomSeparator"] != nil {
 		glue = decompReferenceValue(action.WFWorkflowActionParameters["WFTextCustomSeparator"])
+		hasCustomSeparator = true
 	}
 
-	if glue != "" {
+	if glue != "" || hasCustomSeparator {
 		arguments = append(arguments, fmt.Sprintf("\"%s\"", glueToChar(glue)))
 	}
 

--- a/cherri_test.go
+++ b/cherri_test.go
@@ -209,6 +209,21 @@ func TestCapitalizeEmptyString(t *testing.T) {
 	}
 }
 
+func TestDecompileTextPartsKeepsEmptyCustomSeparator(t *testing.T) {
+	defer resetParser()
+	var arguments = decompTextParts(&ShortcutAction{
+		WFWorkflowActionParameters: map[string]any{
+			"text":                  "items",
+			"WFTextSeparator":       "Custom",
+			"WFTextCustomSeparator": "",
+		},
+	})
+
+	if len(arguments) != 2 || arguments[1] != `""` {
+		t.Fatalf("expected empty custom separator argument, got %#v", arguments)
+	}
+}
+
 func TestSanitizeIdentifierWhitespaceOnly(t *testing.T) {
 	identifier := " "
 	sanitizeIdentifier(&identifier)


### PR DESCRIPTION
This fixes decompiling text actions that use a custom separator set to an empty string.

Previously, decompTextParts only emitted the separator argument when the decompiled separator value was non-empty. That meant an explicit empty custom separator was dropped from the generated Cherri code, changing the behavior of the imported Shortcut.

This keeps track of whether WFTextCustomSeparator was present separately from its value, so an empty string can still be emitted as an intentional argument.

A regression test was added for the empty custom separator case. I verified this with go test -run TestDecompileTextPartsKeepsEmptyCustomSeparator and go test -run TestDecomp.