### PR TITLE
Allow variable body for fileRequest()

### DIFF
--- a/actions/web.cherri
+++ b/actions/web.cherri
@@ -136,7 +136,7 @@ action 'downloadurl' jsonRequest(
 action 'downloadurl' fileRequest(
     text url: 'WFURL',
     HTTPMethod ?method: 'WFHTTPMethod',
-    dictionary! ?body: 'WFRequestVariable',
+    variable ?body: 'WFRequestVariable',
     dictionary! ?headers: 'WFHTTPHeaders',
 ) {
     "WFHTTPBodyType": "File"


### PR DESCRIPTION
Split out from #192 as an unrelated change.

`fileRequest()` sends a file as the request body, so its `body` argument should accept a variable (e.g. a file reference) rather than requiring a literal dictionary. This loosens the `body` parameter from `dictionary!` to `variable` to match how the action is actually used.

Verified with `go build ./...` and `go test -run TestCherriNoSign`.